### PR TITLE
remove assigned DIP numbers from header

### DIFF
--- a/dip-0002.md
+++ b/dip-0002.md
@@ -5,7 +5,6 @@
   Comments-Summary: No comments yet.
   Status: Proposed
   Type: Standard
-  Assigned DIP#: 0002
   Created: 2018-04-30
   License: MIT License
 </pre>

--- a/dip-0003.md
+++ b/dip-0003.md
@@ -5,7 +5,6 @@
   Comments-Summary: No comments yet.
   Status: Proposed
   Type: Standard
-  Assigned DIP#: 0003
   Created: 2018-04-30
   License: MIT License
 </pre>

--- a/dip-0004.md
+++ b/dip-0004.md
@@ -5,7 +5,6 @@
   Comments-Summary: No comments yet.
   Status: Proposed
   Type: Standard
-  Assigned DIP#: 0004
   Created: 2018-04-30
   License: MIT License
 </pre>


### PR DESCRIPTION
These fields are used in the pre-publish state, but are redundant for published
DIPs which have already been assigned a DIP number. As an example, DIP1 does
not have this field.