### PR TITLE
fix typo in dip6 (make 'connection' plural)

### DIFF
--- a/dip-0006.md
+++ b/dip-0006.md
@@ -96,7 +96,7 @@ The DKG and the signing sessions performed after LLMQ activation require many me
 
 As a solution, we introduce the concept of “Intra-Quorum Communication”. Each LLMQ member is required to connect to a deterministically selected set of neighbor members and keep these connections open for the whole DKG and quorum lifetime. The way the required connections are determined ensures that there is always a path with low numbers of hops from each member to each other member. It also ensures that failure of individual members in the LLMQ does not result in total failure of the DKG and LLMQ.
 
-When messages need to be propagated to all other members, the members will then only push inventory items and messages to this deterministic set of connection. The other members will perform the same, until the message is propagated to the whole LLMQ.
+When messages need to be propagated to all other members, the members will then only push inventory items and messages to this deterministic set of connections. The other members will perform the same, until the message is propagated to the whole LLMQ.
 
 ### Building the set of deterministic connections
 


### PR DESCRIPTION
Thanks to @strophy for pointing this out.