### PR TITLE
DIP-0005: Removing non-alphanumeric characters

### DIFF
--- a/dip-0005.md
+++ b/dip-0005.md
@@ -166,7 +166,7 @@ The username field of the Register SubTx must meet the following criteria:
 
 - Minimum length: 3 characters
 - Maximum length: 24 characters
-- Acceptable characters: `A-Z` (case insensitive); `0-9`; underscore `_`; period `.`
+- Acceptable characters: `A-Z` (case insensitive); `0-9`;
   - Note: Usernames are validated as all lowercase characters regardless of the case in the SubTxRegister
 - Unique across the Dash blockchain and current mempool
 - Immutable - the username of a Blockchain User cannot be changed


### PR DESCRIPTION
This change proposes to remove non-alphanumeric characters for the first mainnet release of DIP 0005 Blockchain Users, with the option to add them in later.

The reasoning is based on securing future compatibility when integrating with global name based systems outside of the Dash protocol:

 - Periods (.) are compatible with email but will complicate DNS records using BU names, for example user evan.duffield.xyz.tld requires 2 subdomains for a single BU, whereas evanduffield.xyz.tld requires 1 subdomain per BU
 - Underscores (_) are not compatible with DNS.  They could be translated to hyphens (-) but this would complicate the implementation and is not a clean solution
 - We could implement hyphens (-) but this would break email compatibility
 - Adding these non-alphanumeric characters at mainnet release is making assumptions for the benefit of aesthetics (more choice of characters for users) - but I do not believe this outways the benefits to securing future compatibility with global name based systems we probably want to integrate with in future
 - It is a lot easier to not launch with these special characters and play safe, and add them in later (via HF) if required.  Obviously, BU names are digital assets with a value themselves, so we cannot remove characters later (which would invalidate existing names and essentially seize/liquidate that property)