### PR TITLE
Mention `merkleHashCount` and `merkleFlagsCount` in DIP4

### DIFF
--- a/dip-0004.md
+++ b/dip-0004.md
@@ -107,7 +107,9 @@ The `MNLISTDIFF` message contains a serialized object with the following structu
 | baseBlockHash | uint256 | 32 | Hash of the block on which this diff is based on |
 | blockHash | uint256 | 32 | Hash of the block for which the masternode list diff is returned |
 | totalTransactions | uint32_t | 4 | Number of total transactions in blockHash |
+| merkleHashesCount | compactSize uint | 1-9 | Number of Merkle hashes |
 | merkleHashes | vector<uint256> | variable | Merkle hashes in depth-first order |
+| merkleFlagsCount | compactSize uint | 1-9 | Number of Merkle flag bytes |
 | merkleFlags | vector<uint8_t> | variable | Merkle flag bits, packed per 8 in a byte, least significant bit first |
 | cbTx | CTransaction | variable | The fully serialized coinbase transaction of blockHash |
 | deletedMNs | vector<uint256> | variable | A list of ProRegTx hashes for masternode which were deleted after baseBlockHash |


### PR DESCRIPTION
Added `merkleHashCount` and `merkleFlagsCount` to DIP4 simplified masternode list diff. These fields indicate the number of Merkle hashes and Merkle flags in the tree, respectively.