### PR TITLE
fix broken image path in dip-001

### DIFF
--- a/dip-0001.md
+++ b/dip-0001.md
@@ -110,7 +110,7 @@ Note that blocks mined by non upgraded miners will broadcast version `0x20000000
 
 As in BIP9 each block is assigned a state according to the flow chart:
 
-![State Flow Chart](/dip-0001/states.png)
+![State Flow Chart](dip-0001/states.png)
 
 Above, MTP represents the median time past as in BIP113. The variables starttime and timeout are particular integers that represent the time in the current epoch.
 Here, threshold reached, is a particular boolean we will define below, and denote without the space, `thresholdreached`, in code.


### PR DESCRIPTION
Image path in markdown was incorrect. It began with a `/` which is, of course, root. Path should be relative. I made it relative to the document. -t0dd (aka taw00)