### PR TITLE
[DIP6] Add llmqTypes details to qfcommit

### DIFF
--- a/dip-0006.md
+++ b/dip-0006.md
@@ -364,12 +364,13 @@ The internal Dash message name is `qfcommit` and the format of the message is:
 
 #### Current LLMQ types
 
-| Type | Name | Total Members | Threshold Members | Duration |
-|--|--|--|--|--|
-| 1 | LLMQ_50_60 | 50 | 30 (60%) | 1 Hour |
-| 2 | LLMQ_400_60 | 400 | 240 (60%) | 12 Hours |
-| 3 | LLMQ_400_85 | 400 | 340 (85%) | 24 Hours |
-| 256 | LLMQ_NONE (Reserved) | - | - | - |
+| Type | Name | Total Members | Threshold Members | Duration | Notes |
+|--|--|--|--|--|--|
+| 1 | LLMQ_50_60 | 50 | 30 (60%) | 1 Hour | |
+| 2 | LLMQ_400_60 | 400 | 240 (60%) | 12 Hours | |
+| 3 | LLMQ_400_85 | 400 | 340 (85%) | 24 Hours | |
+| 100 | LLMQ_10_60 | 10 | 6 (60%) | 1 Hour | For testing only |
+| 256 | LLMQ_NONE | - | - | - | Reserved |
 
 ### 7. Mining phase
 

--- a/dip-0006.md
+++ b/dip-0006.md
@@ -370,7 +370,6 @@ The internal Dash message name is `qfcommit` and the format of the message is:
 | 2 | LLMQ_400_60 | 400 | 240 (60%) | 12 Hours | |
 | 3 | LLMQ_400_85 | 400 | 340 (85%) | 24 Hours | |
 | 100 | LLMQ_10_60 | 10 | 6 (60%) | 1 Hour | For testing only |
-| 256 | LLMQ_NONE | - | - | - | Reserved |
 
 ### 7. Mining phase
 

--- a/dip-0006.md
+++ b/dip-0006.md
@@ -351,6 +351,7 @@ The internal Dash message name is `qfcommit` and the format of the message is:
 | Field | Type | Size | Description |
 |--|--|--|--|
 | version | uint16_t | 2 | Version of the final commitment message
+| llmqType | uint8_t | 1 | [Type of LLMQ](#current-llmq-types)
 | quorumHash | uint256 | 32 | The quorum identifier
 | signersSize | compactSize uint | 1-9 | Bit size of the signers bitvector
 | signers | byte[] | (bitSize + 7) / 8 | Bitset representing the aggregated signers of this final commitment
@@ -360,6 +361,15 @@ The internal Dash message name is `qfcommit` and the format of the message is:
 | quorumVvecHash | uint256 | 32 | The hash of the quorum verification vector
 | quorumSig | BLSSig | 96 | Recovered threshold signature
 | sig | BLSSig | 96 | Aggregated BLS signatures from all included commitments
+
+#### Current LLMQ types
+
+| Type | Name | Total Members | Threshold Members | Duration |
+|--|--|--|--|--|
+| 1 | LLMQ_50_60 | 50 | 30 (60%) | 1 Hour |
+| 2 | LLMQ_400_60 | 400 | 240 (60%) | 12 Hours |
+| 3 | LLMQ_400_85 | 400 | 340 (85%) | 24 Hours |
+| 256 | LLMQ_NONE (Reserved) | - | - | - |
 
 ### 7. Mining phase
 


### PR DESCRIPTION
Aligns the DIP with the Dash Core implementation details referenced in the issue.
Closes #36 