### PR TITLE
Fix rendering of code block and use fenced blocks

### DIFF
--- a/dip-0010.md
+++ b/dip-0010.md
@@ -84,7 +84,9 @@ When a transaction is eligible for InstantSend, each masternode should try to
 initiate a signing request for each of the transaction’s inputs. The request
 id is:
 
-    hash("inlock", prevTxHash, prevTxOut)
+```
+hash("inlock", prevTxHash, prevTxOut)
+```
 
 `"inlock"` is a static string, prepended with the length (6, as a compact int,
 which is a single byte) of the string. The message hash of the signing request
@@ -110,8 +112,9 @@ message.
 Finalization is simply another signing request, performed on a (potentially)
 different LLMQ than used before. The request id of the new signing request is:
 
-    hash("islock", inputCount, prevTxHash1, prevTxOut1, prevTxHash2,
-prevTxOut2, ...)
+```
+hash("islock", inputCount, prevTxHash1, prevTxOut1, prevTxHash2, prevTxOut2, ...)
+```
 
 `"islock"` is a static string, prepended with the length (6, as a compact int,
 which is a single byte) of the string. `inputCount` is a compact int,


### PR DESCRIPTION
The fences aren't actually necessary, but make it easier (IMO) to delineate the
code block and not worry about number of leading spaces.

Previous to this the bottom code snippet was only rendering as code up to the newline, and the final part (`prevTxOut2, ...)` was displayed as normal (non-code) text.