### PR TITLE
Modify title and Abstract

### DIFF
--- a/dip-0008.md
+++ b/dip-0008.md
@@ -1,6 +1,6 @@
 <pre>
   DIP: 0008
-  Title: ChainLocks
+  Title: ChainLocks to Provide a Post Nakamoto Consensus
   Author(s): Alexander Block
   Special-Thanks: Andy Freer, Samuel Westrich, Thephez, Udjinm6
   Comments-Summary: No comments yet.
@@ -32,6 +32,12 @@ This DIP introduces ChainLocks, a technology for near-instant confirmation
 of blocks and finding near-instant consensus on the longest valid/accepted
 chain. ChainLocks leverages LLMQ Signing Requests/Sessions to accomplish
 this.
+
+[The original proposal by Satoshi Nakamoto](https://www.bitcoin.com/bitcoin.pdf) 
+provided a novel solution to the Byzantine general's problem.  In some publications, 
+this new consensuses mechanism is called a Nakamoto Consensus.  ChainLocks provide for 
+an advancement of this consensus mechanism which mitigates a 51% attack.  We call 
+the updated consensus mechanism that ChainLocks provide a post Nakamoto consensus.  
 
 ## Motivation
 

--- a/dip-0008.md
+++ b/dip-0008.md
@@ -35,7 +35,7 @@ this.
 
 [The original proposal by Satoshi Nakamoto](https://www.bitcoin.com/bitcoin.pdf) 
 provided a novel solution to the Byzantine general's problem.  In some publications, 
-this new consensuses mechanism is called a Nakamoto Consensus.  ChainLocks provide for 
+this new consensuses mechanism is called a Nakamoto Consensus.  ChainLocks provides for 
 an advancement of this consensus mechanism which mitigates a 51% attack.  We call 
 the updated consensus mechanism that ChainLocks provide a post Nakamoto consensus.  
 

--- a/dip-0008.md
+++ b/dip-0008.md
@@ -35,7 +35,7 @@ this.
 
 [The original proposal by Satoshi Nakamoto](https://www.bitcoin.com/bitcoin.pdf) 
 provided a novel solution to the Byzantine general's problem.  In some publications, 
-this new consensuses mechanism is called a Nakamoto consensus.  ChainLocks provides for 
+this new consensuses mechanism is called a Nakamoto consensus. ChainLocks provides 
 an advancement of this consensus mechanism which mitigates 51% attacks.  We call 
 the updated consensus mechanism that ChainLocks provides a Synergy Consensus.  
 

--- a/dip-0008.md
+++ b/dip-0008.md
@@ -36,7 +36,7 @@ this.
 [The original proposal by Satoshi Nakamoto](https://www.bitcoin.com/bitcoin.pdf) 
 provided a novel solution to the Byzantine general's problem.  In some publications, 
 this new consensuses mechanism is called a Nakamoto Consensus.  ChainLocks provides for 
-an advancement of this consensus mechanism which mitigates a 51% attack.  We call 
+an advancement of this consensus mechanism which mitigates 51% attacks.  We call 
 the updated consensus mechanism that ChainLocks provide a post Nakamoto consensus.  
 
 ## Motivation

--- a/dip-0008.md
+++ b/dip-0008.md
@@ -34,7 +34,7 @@ chain. ChainLocks leverages LLMQ Signing Requests/Sessions to accomplish
 this.
 
 [The original proposal by Satoshi Nakamoto](https://www.bitcoin.com/bitcoin.pdf) 
-provided a novel solution to the Byzantine general's problem.  In some publications, 
+provided a novel solution to the Byzantine general's problem. In some publications, 
 this new consensuses mechanism is called a Nakamoto consensus. ChainLocks provides 
 an advancement of this consensus mechanism which mitigates 51% attacks. We call 
 the updated consensus mechanism that ChainLocks provides a Synergy Consensus.  

--- a/dip-0008.md
+++ b/dip-0008.md
@@ -37,7 +37,7 @@ this.
 provided a novel solution to the Byzantine general's problem.  In some publications, 
 this new consensuses mechanism is called a Nakamoto Consensus.  ChainLocks provides for 
 an advancement of this consensus mechanism which mitigates 51% attacks.  We call 
-the updated consensus mechanism that ChainLocks provide a post Nakamoto consensus.  
+the updated consensus mechanism that ChainLocks provides a post Nakamoto consensus.  
 
 ## Motivation
 

--- a/dip-0008.md
+++ b/dip-0008.md
@@ -1,6 +1,6 @@
 <pre>
   DIP: 0008
-  Title: ChainLocks to Provide a Post Nakamoto Consensus
+  Title: ChainLocks to Provide a Synergy Consensus
   Author(s): Alexander Block
   Special-Thanks: Andy Freer, Samuel Westrich, Thephez, Udjinm6
   Comments-Summary: No comments yet.
@@ -35,9 +35,9 @@ this.
 
 [The original proposal by Satoshi Nakamoto](https://www.bitcoin.com/bitcoin.pdf) 
 provided a novel solution to the Byzantine general's problem.  In some publications, 
-this new consensuses mechanism is called a Nakamoto Consensus.  ChainLocks provides for 
+this new consensuses mechanism is called a Nakamoto consensus.  ChainLocks provides for 
 an advancement of this consensus mechanism which mitigates 51% attacks.  We call 
-the updated consensus mechanism that ChainLocks provides a post Nakamoto consensus.  
+the updated consensus mechanism that ChainLocks provides a Synergy Consensus.  
 
 ## Motivation
 

--- a/dip-0008.md
+++ b/dip-0008.md
@@ -36,7 +36,7 @@ this.
 [The original proposal by Satoshi Nakamoto](https://www.bitcoin.com/bitcoin.pdf) 
 provided a novel solution to the Byzantine general's problem.  In some publications, 
 this new consensuses mechanism is called a Nakamoto consensus. ChainLocks provides 
-an advancement of this consensus mechanism which mitigates 51% attacks.  We call 
+an advancement of this consensus mechanism which mitigates 51% attacks. We call 
 the updated consensus mechanism that ChainLocks provides a Synergy Consensus.  
 
 ## Motivation


### PR DESCRIPTION
The proposed changes provide for emphasis of the fact that ChainLocks strengthens the consensus mechanism.  

The introduction of the term "post Nakamoto consensus" will help me in the literature.  People can use the term ChainLocks when they want to talk about the technology.  I can use post Nakamoto Consensus when referring to how the game theory is different.