### PR TITLE
Changed Status from 'Proposed' to 'Final'

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,11 @@ Number | Layer | Title | Owner | Type | Status
 [3](dip-0003.md) | Consensus | Deterministic Masternode Lists | Samuel Westrich, Alexander Block, Andy Freer, Darren Tapp, Timothy Flynn, Udjinm6, Will Wray | Standard | Final
 [4](dip-0004.md) | Consensus | Simplified Verification of Deterministic Masternode Lists | Alexander Block, Samuel Westrich, UdjinM6, Andy Freer | Standard | Final
 [5](dip-0005.md) | Consensus | Blockchain Users | Alexander Block, Cofresi, Andy Freer, Nathan Marley, Anton Suprunchuk, Darren Tapp, Thephez, Udjinm6, Alex Werner, Samuel Westrich | Standard | Proposed
-[6](dip-0006.md) | Consensus | Long-Living Masternode Quorums | Alexander Block | Standard | Active
-[7](dip-0007.md) | Consensus | LLMQ Signing Requests / Sessions | Alexander Block | Standard | Active
-[8](dip-0008.md) | Consensus | ChainLocks | Alexander Block | Standard | Active
+[6](dip-0006.md) | Consensus | Long-Living Masternode Quorums | Alexander Block | Standard | Final
+[7](dip-0007.md) | Consensus | LLMQ Signing Requests / Sessions | Alexander Block | Standard | Final
+[8](dip-0008.md) | Consensus | ChainLocks | Alexander Block | Standard | Final
 [9](dip-0009.md) | Applications | Feature Derivation Paths | Samuel Westrich | Informational | Proposed
-[10](dip-0010.md) | Consensus | LLMQ InstantSend | Alexander Block | Standard | Proposed
+[10](dip-0010.md) | Consensus | LLMQ InstantSend | Alexander Block | Standard | Final
 
 
 ## License

--- a/dip-0006.md
+++ b/dip-0006.md
@@ -4,7 +4,7 @@
   Author(s):  Alexander Block
   Special-Thanks: Cofresi, Darren Tapp, Thephez, Samuel Westrich
   Comments-Summary: No comments yet.
-  Status: Active
+  Status: Final
   Type: Standard
   Created: 2018-09-07
   License: MIT License

--- a/dip-0007.md
+++ b/dip-0007.md
@@ -4,7 +4,7 @@
   Author(s):  Alexander Block
   Special-Thanks: Cofresi, Darren Tapp, Thephez, Samuel Westrich
   Comments-Summary: No comments yet.
-  Status: Active
+  Status: Final
   Type: Standard
   Created: 2018-09-07
   License: MIT License

--- a/dip-0008.md
+++ b/dip-0008.md
@@ -4,7 +4,7 @@
   Author(s): Alexander Block
   Special-Thanks: Andy Freer, Samuel Westrich, Thephez, Udjinm6
   Comments-Summary: No comments yet.
-  Status: Active
+  Status: Final
   Type: Standard
   Created: 2018-11-16
   License: MIT License

--- a/dip-0010.md
+++ b/dip-0010.md
@@ -3,7 +3,7 @@
   Title: LLMQ InstantSend
   Author(s): Alexander Block
   Special-Thanks:
-  Status: Proposed
+  Status: Final
   Type: Standard
   Created: 2019-05-16
   License: MIT License


### PR DESCRIPTION
LLMQ InstantSend has been active for nearly a month now, I assume it can be set to Final to avoid causing confusion.