### PR TITLE
fix: correct copyright name in DIPs 1-7

### DIFF
--- a/dip-0001.md
+++ b/dip-0001.md
@@ -234,4 +234,4 @@ Also existing nodes may not agree on a chain if the spork was ever rolled back.
 
 ## Copyright
 
-Copyright (c) 2017 Dash Core Team.  [Licensed under MIT License](https://opensource.org/licenses/MIT)
+Copyright (c) 2017 Dash Core Group, Inc.  [Licensed under MIT License](https://opensource.org/licenses/MIT)

--- a/dip-0002.md
+++ b/dip-0002.md
@@ -86,4 +86,4 @@ The idea is to minimize the work necessary for future network wide upgrades. Onl
 
 ## Copyright
 
-Copyright (c) 2018 Dash Core Team. [Licensed under the MIT License](https://opensource.org/licenses/MIT)
+Copyright (c) 2018 Dash Core Group, Inc. [Licensed under the MIT License](https://opensource.org/licenses/MIT)

--- a/dip-0003.md
+++ b/dip-0003.md
@@ -313,4 +313,4 @@ The individual quorum types present in Dash are not subject to this DIP and shou
 
 ## Copyright
 
-Copyright (c) 2018 Dash Core Team. [Licensed under the MIT License](https://opensource.org/licenses/MIT)
+Copyright (c) 2018 Dash Core Group, Inc. [Licensed under the MIT License](https://opensource.org/licenses/MIT)

--- a/dip-0004.md
+++ b/dip-0004.md
@@ -184,4 +184,4 @@ the previous section and perform the following additional steps:
 
 ## Copyright
 
-Copyright (c) 2018 Dash Core Team. [Licensed under the MIT License](https://opensource.org/licenses/MIT)
+Copyright (c) 2018 Dash Core Group, Inc. [Licensed under the MIT License](https://opensource.org/licenses/MIT)

--- a/dip-0005.md
+++ b/dip-0005.md
@@ -231,4 +231,4 @@ A version 1 SubTxCloseAccount is **_invalid_** if _any_ of these conditions are 
 
 ## Copyright
 
-Copyright (c) 2018 Dash Core Team. [Licensed under the MIT License](https://opensource.org/licenses/MIT)
+Copyright (c) 2018 Dash Core Group, Inc. [Licensed under the MIT License](https://opensource.org/licenses/MIT)

--- a/dip-0006.md
+++ b/dip-0006.md
@@ -423,4 +423,4 @@ in [Parameters/Variables of a LLMQ and DKG](#parametersvariables-of-a-llmq-and-d
 
 ## Copyright
 
-Copyright (c) 2018 Dash Core Team. [Licensed under the MIT License](https://opensource.org/licenses/MIT)
+Copyright (c) 2018 Dash Core Group, Inc. [Licensed under the MIT License](https://opensource.org/licenses/MIT)

--- a/dip-0007.md
+++ b/dip-0007.md
@@ -169,4 +169,4 @@ These operations will also be made available through RPC APIs so that external a
 
 ## Copyright
 
-Copyright (c) 2018 Dash Core Team. [Licensed under the MIT License](https://opensource.org/licenses/MIT)
+Copyright (c) 2018 Dash Core Group, Inc. [Licensed under the MIT License](https://opensource.org/licenses/MIT)


### PR DESCRIPTION
Admin fix to update some of the earlier DIP copyrights. They will now match the more recent ones that are already correctly associated with the network-owned DCG.