### PR TITLE
docs(dip-12): add missing file

### DIFF
--- a/dip-0012/dpns-contract-documents.json
+++ b/dip-0012/dpns-contract-documents.json
@@ -1,0 +1,133 @@
+{
+  "domain": {
+    "indices": [
+      {
+        "properties": [
+          {
+            "normalizedParentDomainName": "asc"
+          },
+          {
+            "normalizedLabel": "asc"
+          }
+        ],
+        "unique": true
+      },
+      {
+        "properties": [
+          {
+            "records.dashUniqueIdentityId": "asc"
+          }
+        ],
+        "unique": true
+      }
+    ],
+    "properties": {
+      "label": {
+        "type": "string",
+        "pattern": "^((?!-)[a-zA-Z0-9-]{0,62}[a-zA-Z0-9])$",
+        "minLength": 3,
+        "maxLength": 63,
+        "description": "Domain label. e.g. 'Bob'."
+      },
+      "normalizedLabel": {
+        "type": "string",
+        "pattern": "^((?!-)[a-z0-9-]{0,62}[a-z0-9])$",
+        "maxLength": 63,
+        "description": "Domain label in a lower case for case insensitive uniqueness validation. e.g. 'bob'",
+        "$comment": "This property will be deprecated due to case insensitive indices. Must be equal to label in lowercase"
+      },
+      "normalizedParentDomainName": {
+        "type": "string",
+        "pattern": "^$|^((?!-)[a-z0-9-\\.]{0,189}[a-z0-9])$",
+        "minLength": 0,
+        "maxLength": 190,
+        "description": "A full parent domain name in lower case for case insensitive uniqueness validation. e.g. 'dash'",
+        "$comment": "Must be equal to existing domain or can be empty if you want to create a top level domain. Only the contract owner can create top level domains"
+      },
+      "preorderSalt": {
+        "type": "string",
+        "contentEncoding": "base64",
+        "minLength": 43,
+        "maxLength": 43,
+        "pattern": "^([A-Za-z0-9+/])*$",
+        "description": "Domain pre-order salt. 32 random bytes"
+      },
+      "records": {
+        "type": "object",
+        "properties": {
+          "dashUniqueIdentityId": {
+            "type": "string",
+            "minLength": 42,
+            "maxLength": 44,
+            "pattern": "^[123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]+$",
+            "description": "Identity ID string should be used to create a primary name for Identity. base58 string",
+            "$comment": "Should be equal to the document owner"
+          },
+          "dashAliasIdentityId": {
+            "type": "string",
+            "minLength": 42,
+            "maxLength": 44,
+            "pattern": "^[123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]+$",
+            "description": "Identity ID string should be used to create multiple alias names for Identity. base58 string",
+            "$comment": "Should be equal to the document owner"
+          }
+        },
+        "$comment": "Constraint with max and min properties ensure that only one identity record is used either `dashUniqueIdentityId` or `dashAliasIdentityId`",
+        "minProperties": 1,
+        "maxProperties": 1,
+        "additionalProperties": false
+      },
+      "subdomainRules": {
+        "type": "object",
+        "properties": {
+          "allowSubdomains": {
+            "type": "boolean",
+            "description": "This option defines who can create subdomains"
+          }
+        },
+        "description": "Subdomain rules allows to define rules for subdomains",
+        "additionalProperties": false,
+        "required": [
+          "allowSubdomains"
+        ]
+      }
+    },
+    "required": [
+      "label",
+      "normalizedLabel",
+      "normalizedParentDomainName",
+      "preorderSalt",
+      "records",
+      "subdomainRules"
+    ],
+    "additionalProperties": false,
+    "$comment": "In order to register domain you need to create a preorder. The preorder step is needed to prevent man-in-the-middle attacks. normalizedLabel + '.' + normalizedParentDomain must not be longer than 253 chars length as defined by RFC 1035. Domain documents are immutable: modification and deletion are restricted"
+  },
+  "preorder": {
+    "indices": [
+      {
+        "properties": [
+          {
+            "saltedDomainHash": "asc"
+          }
+        ],
+        "unique": true
+      }
+    ],
+    "properties": {
+      "saltedDomainHash": {
+        "type": "string",
+        "contentEncoding": "base64",
+        "minLength": 43,
+        "maxLength": 43,
+        "pattern": "^([A-Za-z0-9+/])*$",
+        "description": "Double sha-256 of concatenated salt, `normalizedLabel` and `normalizedParentDomainName`. Salt should be 32 random bytes"
+      }
+    },
+    "required": [
+      "saltedDomainHash"
+    ],
+    "additionalProperties": false,
+    "$comment": "Preorder documents are immutable: modification and deletion are restricted"
+  }
+}


### PR DESCRIPTION
The DIP links to the file being added [here](https://github.com/dashpay/dips/blob/master/dip-0012.md#data-contract-document-schema). It was missing from the initial PR.