### PR TITLE
dip6: Some fixes in the DKG message tables

### DIFF
--- a/dip-0006.md
+++ b/dip-0006.md
@@ -262,8 +262,7 @@ The internal Dash message name is `qjustify` and the format of the message is:
 | quorumHash | uint256 | 32 | The quorum identifier
 | proTxHash | uint256 | 32 | The proTxHash of the justifying member
 | skCount | compactSize uint | 1-9 | Number of unencrypted secret key contributions
-| skContributionMembers | uint32[] | 4 * skCount | Indexes of the members for which justifications are provided
-| skContributions | BLSSecKey[] | 32 * skCount | Unencrypted secret key contributions for the members contained in skContributionMembers
+| skContributions | pair(uint32[], BLSSecKey[]) | (4 + 32) * skCount |  Unencrypted secret key contributions with indexes of the corresponding members
 | sig | BLSSig | 96 | BLS signature, signed with the operator key of the contributing masternode
 
 ### 5. Commitment phase

--- a/dip-0006.md
+++ b/dip-0006.md
@@ -186,6 +186,7 @@ The internal Dash message name is `qcontrib` and the format of the message is:
 | vvecSize | compactSize uint | 1-9 | The size of the verification vector
 | vvec | BLSPubKey[] | 48 * vvecSize | The verification vector
 | ephemeralPubKey | BLSPubKey | 48 | Ephemeral BLS public key used to encrypt secret key contributions
+| ivSeed | uint256 | 32 | Seed used to create the AES initialization vectors for all members
 | skCount | compactSize uint | 1-9 | Number of encrypted secret key contributions
 | skContributions | byte[] | 32 * skCount | Secret key contributions encrypted to recipient masternodes’ BLS public operator key
 | sig | BLSSig | 96 | BLS signature, signed with the operator key of the contributing masternode

--- a/dip-0006.md
+++ b/dip-0006.md
@@ -227,9 +227,9 @@ The internal Dash message name is `qcomplaint` and the format of the message is:
 | quorumHash | uint256 | 32 | The quorum identifier
 | proTxHash | uint256 | 32 | The proTxHash of the complaining member
 | badBitSize | compactSize uint | 1-9 | Number of bits in the bad members bitvector
-| badMembers | byte[] | (bitSize + 7) / 8 | The bad members bitvector
+| badMembers | byte[] | (badBitSize + 7) / 8 | The bad members bitvector
 | complaintsBitSize | compactSize uint | 1-9 | Number of bits in the complaints bitvector
-| complaints | byte[] | (bitSize + 7) / 8 | The complaints bitvector
+| complaints | byte[] | (complaintsBitSize + 7) / 8 | The complaints bitvector
 | sig | BLSSig | 96 | BLS signature, signed with the operator key of the contributing masternode
 
 ### 4. Justification phase
@@ -308,7 +308,7 @@ The internal Dash message name is `qpcommit` and the format of the message is:
 | quorumHash | uint256 | 32 | The quorum identifier
 | proTxHash | uint256 | 32 | The proTxHash of the committing member
 | validMembersSize | compactSize uint | 1-9 | Bit size of the validMembers bitvector
-| validMembers | byte[] | (bitSize + 7) / 8 | Bitset of valid members in this commitment
+| validMembers | byte[] | (validMembersSize + 7) / 8 | Bitset of valid members in this commitment
 | quorumPublicKey | BLSPubKey | 48 | The quorum public key
 | quorumVvecHash | uint256 | 32 | The SHA256 hash of the quorum verification vector
 | quorumSig | BLSSig | 96 | Threshold signature, signed with the threshold signature share of the committing member
@@ -354,9 +354,9 @@ The internal Dash message name is `qfcommit` and the format of the message is:
 | llmqType | uint8_t | 1 | [Type of LLMQ](#current-llmq-types)
 | quorumHash | uint256 | 32 | The quorum identifier
 | signersSize | compactSize uint | 1-9 | Bit size of the signers bitvector
-| signers | byte[] | (bitSize + 7) / 8 | Bitset representing the aggregated signers of this final commitment
+| signers | byte[] | (signersSize + 7) / 8 | Bitset representing the aggregated signers of this final commitment
 | validMembersSize | compactSize uint | 1-9 | Bit size of the validMembers bitvector
-| validMembers | byte[] | (bitSize + 7) / 8 | Bitset of valid members in this commitment
+| validMembers | byte[] | (validMembersSize + 7) / 8 | Bitset of valid members in this commitment
 | quorumPublicKey | BLSPubKey | 48 | The quorum public key
 | quorumVvecHash | uint256 | 32 | The SHA256 hash of the quorum verification vector
 | quorumSig | BLSSig | 96 | Recovered threshold signature

--- a/dip-0006.md
+++ b/dip-0006.md
@@ -261,9 +261,9 @@ The internal Dash message name is `qjustify` and the format of the message is:
 | llmqType | uint8_t | 1 | The LLMQ type
 | quorumHash | uint256 | 32 | The quorum identifier
 | proTxHash | uint256 | 32 | The proTxHash of the justifying member
-| skContributionsCount | compactSize uint | 1-9 | Number of unencrypted secret key contributions
-| skContributionMembers | uint32[] | 4 * count | Indexes of the members for which justifications are provided
-| skContributions | BLSSecKey[] | 32 * count | Unencrypted secret key contributions for the members contained in skContributionMembers
+| skCount | compactSize uint | 1-9 | Number of unencrypted secret key contributions
+| skContributionMembers | uint32[] | 4 * skCount | Indexes of the members for which justifications are provided
+| skContributions | BLSSecKey[] | 32 * skCount | Unencrypted secret key contributions for the members contained in skContributionMembers
 | sig | BLSSig | 96 | BLS signature, signed with the operator key of the contributing masternode
 
 ### 5. Commitment phase


### PR DESCRIPTION
c789750 See [quorums_dkgsession.h#L129](https://github.com/dashpay/dash/blob/43d2973a0e89ac9435142d6379e664c0ec20b2a2/src/llmq/quorums_dkgsession.h#L129) and [quorums_dkgsession.h#L141](https://github.com/dashpay/dash/blob/43d2973a0e89ac9435142d6379e664c0ec20b2a2/src/llmq/quorums_dkgsession.h#L141)

206a3c7 See [quorums_dkgsession.h#43](https://github.com/dashpay/dash/blob/43d2973a0e89ac9435142d6379e664c0ec20b2a2/src/llmq/quorums_dkgsession.h#L43) and [quorums_dkgsession.h#L54](https://github.com/dashpay/dash/blob/43d2973a0e89ac9435142d6379e664c0ec20b2a2/src/llmq/quorums_dkgsession.h#L54) which has the iv here [bls_ies.h#L86](https://github.com/dashpay/dash/blob/43d2973a0e89ac9435142d6379e664c0ec20b2a2/src/bls/bls_ies.h#L86) and in serializations ([bls_ies.h#L107](https://github.com/dashpay/dash/blob/43d2973a0e89ac9435142d6379e664c0ec20b2a2/src/bls/bls_ies.h#L107)) between `ephemeralPubKey` and `blobs` 

I guess the others are obvious.

