### PR TITLE
DIP14: fix 256-bit version bytes

### DIFF
--- a/dip-0014.md
+++ b/dip-0014.md
@@ -183,8 +183,8 @@ Because of the choice of the version bytes, the Base58 representation will start
 
 If (child number >= 2<sup>31</sup>) then serialize the following way :
 
-* 4 byte: version bytes (mainnet: `0x02FD9CD5` public, `0x02FD9CEA` private; testnet: `0x02FDA7E8`
-  public, `0x02FDA7FD` private)
+* 4 byte: version bytes (mainnet: `0x0eecefc5` public, `0x0eecf02e` private; testnet: `0x0eed270b`
+  public, `0x0eed2774` private)
 * 1 byte: depth: 0x00 for master nodes, 0x01 for level-1 derived keys, ....
 * 4 bytes: the fingerprint of the parent's key (0x00000000 if master key)
 * 1 byte: hardening: 0x00 if not hardened, 0x01 if hardened

--- a/dip-0014.md
+++ b/dip-0014.md
@@ -183,8 +183,8 @@ Because of the choice of the version bytes, the Base58 representation will start
 
 If (child number >= 2<sup>31</sup>) then serialize the following way :
 
-* 4 byte: version bytes (mainnet: `0x0eecefc5` public, `0x0eecf02e` private; testnet: `0x0eed270b`
-  public, `0x0eed2774` private)
+* 4 byte: version bytes (mainnet: `0X0EECEFC5` public, `0x0EECF02E` private; testnet: `0x0EED270B`
+  public, `0x0EED2774` private)
 * 1 byte: depth: 0x00 for master nodes, 0x01 for level-1 derived keys, ....
 * 4 bytes: the fingerprint of the parent's key (0x00000000 if master key)
 * 1 byte: hardening: 0x00 if not hardened, 0x01 if hardened


### PR DESCRIPTION
update version bytes to encode to expected base58 chars, closes #80 