### PR TITLE
Remove DIP5 transaction types

### DIFF
--- a/dip-0002-special-transactions.md
+++ b/dip-0002-special-transactions.md
@@ -12,7 +12,3 @@ may introduce more types.
 | 4 | Provider Update Revocation Transaction (ProUpRevTx) | [DIP 003: Deterministic Masternode List](https://github.com/dashpay/dips/blob/master/dip-0003.md) | 1 |	Active |
 | 5 | Coinbase Transaction (CbTx) | [DIP 004: Simplified Verification of Deterministic Masternode Lists](https://github.com/dashpay/dips/blob/master/dip-0004.md) | 2 |	Active |
 | 6 | Quorum Commitment | [DIP 006: Long Living Masternode Quorums](https://github.com/dashpay/dips/blob/master/dip-0006.md) | 1 | Active |
-| 8 | Register Subscription Transaction (SubTxRegister) | [DIP 005: Blockchain Users](https://github.com/dashpay/dips/blob/master/dip-0005.md) | 1 |	Proposed |
-| 9 | Topup BU Credit Subscription Transaction (SubTxTopup) | [DIP 005: Blockchain Users](https://github.com/dashpay/dips/blob/master/dip-0005.md) | 1 |	Proposed |
-| 10 | Reset BU Key Subscription Transaction (SubTxResetKey) | [DIP 005: Blockchain Users](https://github.com/dashpay/dips/blob/master/dip-0005.md) | 1 |	Proposed |
-| 11 | Close BU Account Subscription Transaction (SubTxCloseAccount) | [DIP 005: Blockchain Users](https://github.com/dashpay/dips/blob/master/dip-0005.md) | 1 |	Proposed |

--- a/dip-0005.md
+++ b/dip-0005.md
@@ -64,8 +64,6 @@ In addition to the payload in the special transaction section of the transaction
 
 `OP_RETURN amount = signup fee + amount to convert to credits`
 
-The special transaction type used for Register Subscription Transactions is 8.
-
 The transaction consists of the following data in the payload area:
 
 | Name | Type | Size | Description |
@@ -81,8 +79,6 @@ The transaction consists of the following data in the payload area:
 A Topup SubTx (SubTxTopup) increases the user’s credit balance by the amount of Dash burned in the transaction.  The Topup SubTx does not need to be signed by the blockchain user, so anyone can topup an account.  The Registration SubTx hash identifies the account receiving the topup.
 
 Similar to the SubTxRegister, the SubTxTopup must spend the amount to be converted to credits using an `OP_RETURN` output.
-
-The special transaction type used for Topup Subscription Transactions is 9.
 
 The transaction consists of the following data in the payload area:
 
@@ -101,8 +97,6 @@ Once a SubTxResetKey is mined, the key that signed the transaction is rendered i
 
 * `Age = (Current block) - (Block containing SubTxResetKey)`
 
-The special transaction type used for ResetKey Subscription Transactions is 10.
-
 The transaction consists of the following data in the payload area:
 
 | Name | Type | Size | Description |
@@ -117,8 +111,6 @@ The transaction consists of the following data in the payload area:
 ### Close Blockchain User Account (SubTxCloseAccount)
 
 The Close SubTx (SubTxCloseAccount) allows a blockchain user to deactivate their username by signing the message with their most recent private key, or in the case of a recently updated public key (via “SubTxResetKey”), a previously used private key.  This latter consideration is to prevent account hijacking attacks. For example, if an attacker obtains a Blockchain User's private key, then changes the public key via ResetKey, the legitimate user can still close the account with their old key.  This can be used to disable the attacker’s ability to access the username and associated data.  To mitigate the risk of account closure due to an old key being compromised, accounts can only be closed using previous keys that are [<= ~90 days old](#key-aging) (51840 blocks).  The private key associated with the currently assigned public key can always be used to Close an account regardless of age.
-
-The special transaction type used for CloseAccount Subscription Transactions is 11.
 
 The transaction consists of the following data in the payload area:
 


### PR DESCRIPTION
DIP5 was withdrawn earlier via https://github.com/dashpay/dips/pull/58