### PR TITLE
Update dip-0010.md

### DIFF
--- a/dip-0010.md
+++ b/dip-0010.md
@@ -56,8 +56,8 @@ LLMQ-based InstantSend allows all transactions to be treated as InstantSend
 transactions. The old system differentiated transactions as InstantSend
 transactions by using the P2P message `ix` instead of `tx`. In the new system,
 such distinction is not required anymore as LLMQs will try to lock every valid
-transaction by default. If an `ix` P2P message is received from an older
-client, nodes should convert these to simple `tx` messages and treat them as
+transaction by default. If `ix` P2P messages are received from older
+clients, nodes should convert these to simple `tx` messages and treat them as
 such (including processing and propagating as `tx`).
 
 ## Used LLMQ type


### PR DESCRIPTION
changed :
If an ix P2P message is received from an older client  -> If `ix` P2P messages are received from older clients