### PR TITLE
DIP3: Fix `payoutStr` description to make sure it matches `scriptPayout` definition

### DIFF
--- a/dip-0003.md
+++ b/dip-0003.md
@@ -89,8 +89,7 @@ The individual parts of the message are:
 1. `<magicString>`: A fixed string which is always "DarkCoin Signed Message:" with a newline character appended.
 Please note that existing tools (e.g. the RPC command `signmessage`) usually add the magicString internally, making it
 unnecessary to manually add it.
-2. `<payoutStr>`: The Dash address corresponding to the scriptPayout field of the ProRegTx. In case scriptPayout is not a
-P2PK/P2PKH/P2SH script, `<payoutStr>` must be set to the hex representation of the full script.
+2. `<payoutStr>`: The Dash address corresponding to the scriptPayout field of the ProRegTx.
 3. `<operatorReward>`: The operatorReward field of the ProRegTx.
 4. `<ownerKeyAddress>`: The Dash address corresponding to the keyIdOwner field of the ProRegTx.
 5. `<votingKeyAddress>`: The Dash address corresponding to the keyIdVoting field of the ProRegTx.


### PR DESCRIPTION
We do not allow anything but p2pkh/p2sh in `scriptPayout`.