### PR TITLE
DIP6: add LLMQ params to table

### DIFF
--- a/dip-0006/llmq-types.md
+++ b/dip-0006/llmq-types.md
@@ -1,11 +1,11 @@
 These are the currently supported LLMQ and DKG types. Each row is a single type. Each column refers to a parameter found
 in [Parameters/Variables of a LLMQ and DKG](../dip-0006.md#parametersvariables-of-a-llmq-and-dkg).
 
-| name | quorumType | quorumSize | quorumMinSize | quorumThreshold | quorumDkgInterval | quorumDkgPhaseBlocks | quorumDkgBadVotesThreshold | quorumSigningActiveQuorumCount | Notes |
-|--|--|--|--|--|--|--|--|--|--|
-| LLMQ_50_60 | 1 | 50 | 40 | 30 (60%) | 24 (1 Hour) | 2 | 40 | 24 | |
-| LLMQ_400_60 | 2 | 400 | 300 | 240 (60%) | 288 (12 Hours) | 4 | 300 | 4 | |
-| LLMQ_400_85 | 3 | 400 | 350 | 340 (85%) | 576 (24 Hours) | 4 | 300 | 4 | |
-| LLMQ_100_67 | 4 | 100 | 80 | 67 (67%) | 24 (1 Hour) | 2 | 80 | 24 | |
-| LLMQ_TEST | 100 | 3 | 2 | 2 (66%) | 24 (1 Hour) | 2 | 2 | 2 | For testing only |
-| LLMQ_DEVNET | 101 | 10 | 7 | 6 (60%) | 24 (1 Hour) | 2 | 7 | 3 | For devnets only |
+| name | quorumType | quorumSize | quorumMinSize | quorumThreshold | quorumDkgInterval | quorumDkgPhaseBlocks | quorumDkgBadVotesThreshold | quorumSigningActiveQuorumCount | keepOldConnections | recoveryMembers | Notes |
+|--|--|--|--|--|--|--|--|--|--|--|--|
+| LLMQ_50_60 | 1 | 50 | 40 | 30 (60%) | 24 (1 Hour) | 2 | 40 | 24 | 25 | 25 | |
+| LLMQ_400_60 | 2 | 400 | 300 | 240 (60%) | 288 (12 Hours) | 4 | 300 | 4 | 5 | 100 | |
+| LLMQ_400_85 | 3 | 400 | 350 | 340 (85%) | 576 (24 Hours) | 4 | 300 | 4 | 5 | 100 | |
+| LLMQ_100_67 | 4 | 100 | 80 | 67 (67%) | 24 (1 Hour) | 2 | 80 | 24 | 25 | 50 | |
+| LLMQ_TEST | 100 | 3 | 2 | 2 (66%) | 24 (1 Hour) | 2 | 2 | 2 | 3 | 3 | For testing only |
+| LLMQ_DEVNET | 101 | 10 | 7 | 6 (60%) | 24 (1 Hour) | 2 | 7 | 3 | 4 | 6 | For devnets only |


### PR DESCRIPTION
Add `keepOldConnections` and `recoveryMembers`