### PR TITLE
DIP2: increment qctx version to match current protocol

### DIFF
--- a/dip-0002-special-transactions.md
+++ b/dip-0002-special-transactions.md
@@ -11,5 +11,5 @@ may introduce more types.
 | 3 | Provider Update Registrar Transaction (ProUpRegTx) | [DIP 003: Deterministic Masternode List](https://github.com/dashpay/dips/blob/master/dip-0003.md) | 1 | Active |
 | 4 | Provider Update Revocation Transaction (ProUpRevTx) | [DIP 003: Deterministic Masternode List](https://github.com/dashpay/dips/blob/master/dip-0003.md) | 1 | Active |
 | 5 | Coinbase Transaction (CbTx) | [DIP 004: Simplified Verification of Deterministic Masternode Lists](https://github.com/dashpay/dips/blob/master/dip-0004.md) | 2 | Active |
-| 6 | Quorum Commitment | [DIP 006: Long Living Masternode Quorums](https://github.com/dashpay/dips/blob/master/dip-0006.md) | 1 | Active |
+| 6 | Quorum Commitment | [DIP 006: Long Living Masternode Quorums](https://github.com/dashpay/dips/blob/master/dip-0006.md) | 2 | Active |
 | 7 | Masternode Hard Fork Signal | [DIP 023: Enhanced Hard Fork Mechanism](https://github.com/dashpay/dips/blob/master/dip-0023.md) | 1 | Proposed |


### PR DESCRIPTION
Dash Core v18 updated the qctx with additional field(s). See the table in https://github.com/dashpay/dips/blob/master/dip-0006.md#6-finalization-phase for details.

Closes #119 