### PR TITLE
dip22 referral fix regarding choosing quorum

### DIFF
--- a/dip-0022.md
+++ b/dip-0022.md
@@ -104,5 +104,5 @@ The new message has the following structure (fields in bold are not present in t
 This updated implementation uses the `LLMQ_60_75` quorum created via the quorum rotation process
 defined in [DIP-0024](dip-0024.md) as opposed to the `LLMQ_50_60` quorum used by the previous
 iteration of InstantSend. Other than this change in quorum type, choosing the active LLMQ to perform
-signing should follow the same steps as defined in [DIP-0007 - Choosing the active LLMQ to perform
-signing](https://github.com/dashpay/dips/blob/master/dip-0007.md#choosing-the-active-llmq-to-perform-signing).
+signing is also changed as defined in [DIP-0024 - Choosing the active Quorum to perform signing
+signing](https://github.com/dashpay/dips/blob/master/dip-0024.md#choosing-the-active-quorum-to-perform-signing).


### PR DESCRIPTION
Currently DIP22 Choosing the active LLMQ to perform signing is partially wrong