### PR TITLE
docs(dip-10): clarify retroactive lock

### DIFF
--- a/dip-0010.md
+++ b/dip-0010.md
@@ -215,8 +215,8 @@ transactions, retroactive signing ensures that even these transactions get
 locked.
 
 This also allows the ChainLocks system to lock the most recent block even if
-it includes unsafe transactions, as these transactions will become safe after
-a short delay.
+it includes transactions that were not locked prior to being mined, as these
+transactions will become locked after a short delay.
 
 ## Dangling Partial Locks
 

--- a/dip-0010.md
+++ b/dip-0010.md
@@ -212,11 +212,9 @@ locally and thus the locking attempt can be skipped. Retroactive signing
 however becomes important when miners include transactions in new blocks which
 are not known by the remainder of the network. As it is desirable to lock all
 transactions, retroactive signing ensures that even these transactions get
-locked.
-
-This also allows the ChainLocks system to lock the most recent block even if
-it includes transactions that were not locked prior to being mined, as these
-transactions will become locked after a short delay.
+locked. Once they are InstantSend-locked, this allows the ChainLocks system to
+lock the most recently mined block even though it originally included
+non-locked transactions.
 
 ## Dangling Partial Locks
 

--- a/dip-0010.md
+++ b/dip-0010.md
@@ -214,9 +214,9 @@ are not known by the remainder of the network. As it is desirable to lock all
 transactions, retroactive signing ensures that even these transactions get
 locked.
 
-This also allows the ChainLocks system to retroactively lock blocks which
-include unsafe transactions, as these transactions will become safe after a
-short delay.
+This also allows the ChainLocks system to retroactively lock the most recent
+block even if it includes unsafe transactions, as these transactions will
+become safe after a short delay.
 
 ## Dangling Partial Locks
 

--- a/dip-0010.md
+++ b/dip-0010.md
@@ -214,9 +214,9 @@ are not known by the remainder of the network. As it is desirable to lock all
 transactions, retroactive signing ensures that even these transactions get
 locked.
 
-This also allows the ChainLocks system to retroactively lock the most recent
-block even if it includes unsafe transactions, as these transactions will
-become safe after a short delay.
+This also allows the ChainLocks system to lock the most recent block even if
+it includes unsafe transactions, as these transactions will become safe after
+a short delay.
 
 ## Dangling Partial Locks
 


### PR DESCRIPTION
Original wording can seem to indicate older blocks might also be ChainLocked. This is not the case, but it could have created issues so we're clarifying the wording to prevent confusion.