### PR TITLE
chore: fix typo in DIP-28

### DIFF
--- a/dip-0028.md
+++ b/dip-0028.md
@@ -205,7 +205,7 @@ generated and stored securely for future use.
 SHOULD adhere to [DIP-9](https://github.com/dashpay/dips/blob/master/dip-0009.md), with feature
 **3’** and subpath **4’/*** (for example, **m/9'/5'/3'/4'**/0').
 
-**platformNodeID** represents first 20 bytes of SHA256 checksum of the public part of the **P2P
+**platformNodeID** is the first 20 bytes of SHA256 checksum of the public part of the **P2P
 key** (SHA256-20). The following pseudocode represents the generation algorithm:
 
 ``` text


### PR DESCRIPTION
> The following new ProRegTx rules are added and are only applicable when `type` is 1:

those rules collide with some already existing rules (checking references to 1K) so the wording is not great but i'm not sure how to edit it here

platformNodeID is/represent the first....