### PR TITLE
chore: DIP4 mnlistdiff adjustment to newer protocol versions

### DIFF
--- a/dip-0004.md
+++ b/dip-0004.md
@@ -151,32 +151,35 @@ To request a full masternode list, a SPV client would set the â€œbaseBlockHashâ€
 
 The `MNLISTDIFF` message contains a serialized object with the following structure:
 
+| Field | Type | Size | Description | Minimum Protocol Version |
+| --- | --- | --- | --- | --- |
+| nVersion | uint16_t | 2 | Version of the `MNLISTDIFF` reply (For now, `nVersion` is always 1) | 70229 |
+| baseBlockHash | uint256 | 32 | Hash of the block on which this diff is based on | --- |
+| blockHash | uint256 | 32 | Hash of the block for which the masternode list diff is returned | --- |
+| totalTransactions | uint32_t | 4 | Number of total transactions in blockHash | --- |
+| merkleHashesCount | compactSize uint | 1-9 | Number of Merkle hashes | --- |
+| merkleHashes | uint256[] | variable | Merkle hashes in depth-first order | --- |
+| merkleFlagsCount | compactSize uint | 1-9 | Number of Merkle flag bytes | --- |
+| merkleFlags | uint8_t[] | variable | Merkle flag bits, packed per 8 in a byte, least significant bit first | --- |
+| cbTx | CTransaction | variable | The fully serialized coinbase transaction of blockHash | --- |
+| deletedMNsCount | compactSize uint | 1-9 | Number of ProRegTx hashes which were deleted after baseBlockHash | --- |
+| deletedMNs | uint256[] | variable | A list of ProRegTx hashes for masternode which were deleted after baseBlockHash | --- |
+| mnCount | compactSize uint | 1-9 | Number of SML entries which were added or updated since baseBlockHash | --- |
+| mnList | SMLEntry[] | variable | The list of SML entries which were added or updated since baseBlockHash | --- |
+| deletedQuorumsCount | compactSize uint | 1-9 | Number of LLMQs which were deleted from the active set after baseBlockHash | --- |
+| deletedQuorums | (uint8_t+uint256)[] | variable | A list of LLMQ type and quorum hashes for LLMQs which were deleted after baseBlockHash | --- |
+| newQuorumsCount | compactSize uint | 1-9 | Number of new LLMQs which were added to the active set since baseBlockHash | --- |
+| newQuorums | qfcommit[] | variable | The list of LLMQ commitments for the LLMQs which were added since baseBlockHash | --- |
+| quorumsCLSigsCount | compactSize uint | 1-9 | Number of entries in quorumsCLSigs field | 70230 |
+| quorumsCLSigs | quorumsCLSigsObject[] | variable | ChainLock signature used to calculate members per quorum indexes (in newQuorums) | 70230 |
+
+Below the description of the `quorumsCLSigsObject` object introduced in the [DIP29 Randomness Beacon For LLMQ Selection](dip-0029.md#light-clients):
+
 | Field | Type | Size | Description |
-| --- | --- | --- | --- |
-| baseBlockHash | uint256 | 32 | Hash of the block on which this diff is based on |
-| blockHash | uint256 | 32 | Hash of the block for which the masternode list diff is returned |
-| totalTransactions | uint32_t | 4 | Number of total transactions in blockHash |
-| merkleHashesCount | compactSize uint | 1-9 | Number of Merkle hashes |
-| merkleHashes | uint256[] | variable | Merkle hashes in depth-first order |
-| merkleFlagsCount | compactSize uint | 1-9 | Number of Merkle flag bytes |
-| merkleFlags | uint8_t[] | variable | Merkle flag bits, packed per 8 in a byte, least significant bit first |
-| cbTx | CTransaction | variable | The fully serialized coinbase transaction of blockHash |
-| deletedMNsCount | compactSize uint | 1-9 | Number of ProRegTx hashes which were deleted after baseBlockHash |
-| deletedMNs | uint256[] | variable | A list of ProRegTx hashes for masternode which were deleted after baseBlockHash |
-| mnCount | compactSize uint | 1-9 | Number of SML entries which were added or updated since baseBlockHash |
-| mnList | SMLEntry[] | variable | The list of SML entries which were added or updated since baseBlockHash |
-| deletedQuorumsCount | compactSize uint | 1-9 | Number of LLMQs which were deleted from the active set after baseBlockHash |
-| deletedQuorums | (uint8_t+uint256)[] | variable | A list of LLMQ type and quorum hashes for LLMQs which were deleted after baseBlockHash |
-| newQuorumsCount | compactSize uint | 1-9 | Number of new LLMQs which were added to the active set since baseBlockHash |
-| newQuorums | qfcommit[] | variable | The list of LLMQ commitments for the LLMQs which were added since baseBlockHash |
-
-Starting with protocol version 70229, the following field is added to the `MNLISTDIFF` message just after `baseBlockHash`.
-
-| Field               | Type | Size | Description                       |
-|---------------------| ---- | ---- |-----------------------------------|
-| nVersion            | uint16_t | 2 | Version of the `MNLISTDIFF` reply |
-
-For now, `nVersion` is always 1.
+|--|--|--|--|
+| signature | BLSSig | 96 | ChainLock Signature |
+| indexSetCount | compactSize uint | 1-9 | Number of quorum indexes using the same signature for their member calculation
+| indexSet | uint16_t[] | variable | Quorum indexes indicating which newQuorums entries use this signature for their member calculation
 
 ## Tracking/Updating and verifying masternode lists based on MNLISTDIFF
 

--- a/dip-0004.md
+++ b/dip-0004.md
@@ -173,7 +173,7 @@ The `MNLISTDIFF` message contains a serialized object with the following structu
 | quorumsCLSigsCount | compactSize uint | 1-9 | Number of entries in quorumsCLSigs field | 70230 |
 | quorumsCLSigs | quorumsCLSigsObject[] | variable | ChainLock signature used to calculate members per quorum indexes (in newQuorums) | 70230 |
 
-Below the description of the `quorumsCLSigsObject` object introduced in the [DIP29 Randomness Beacon For LLMQ Selection](dip-0029.md#light-clients):
+The format of the `quorumsCLSigsObject` object introduced in the [DIP29 Randomness Beacon For LLMQ Selection](dip-0029.md#light-clients) is:
 
 | Field | Type | Size | Description |
 |--|--|--|--|

--- a/dip-0004.md
+++ b/dip-0004.md
@@ -165,11 +165,6 @@ The `MNLISTDIFF` message contains a serialized object with the following structu
 | deletedMNs | uint256[] | variable | A list of ProRegTx hashes for masternode which were deleted after baseBlockHash |
 | mnCount | compactSize uint | 1-9 | Number of SML entries which were added or updated since baseBlockHash |
 | mnList | SMLEntry[] | variable | The list of SML entries which were added or updated since baseBlockHash |
-
-Starting with protocol version 70214, the following fields are added to the `MNLISTDIFF` message.
-
-| Field | Type | Size | Description |
-| --- | --- | --- | --- |
 | deletedQuorumsCount | compactSize uint | 1-9 | Number of LLMQs which were deleted from the active set after baseBlockHash |
 | deletedQuorums | (uint8_t+uint256)[] | variable | A list of LLMQ type and quorum hashes for LLMQs which were deleted after baseBlockHash |
 | newQuorumsCount | compactSize uint | 1-9 | Number of new LLMQs which were added to the active set since baseBlockHash |

--- a/dip-0004.md
+++ b/dip-0004.md
@@ -175,7 +175,7 @@ Starting with protocol version 70214, the following fields are added to the `MNL
 | newQuorumsCount | compactSize uint | 1-9 | Number of new LLMQs which were added to the active set since baseBlockHash |
 | newQuorums | qfcommit[] | variable | The list of LLMQ commitments for the LLMQs which were added since baseBlockHash |
 
-Starting with protocol version 70225, the following field is added to the `MNLISTDIFF` message between `cbTx` and `deletedQuorumsCount`.
+Starting with protocol version 70229, the following field is added to the `MNLISTDIFF` message just after `baseBlockHash`.
 
 | Field               | Type | Size | Description                       |
 |---------------------| ---- | ---- |-----------------------------------|


### PR DESCRIPTION
- Added minimum protocol version column.
- Decided to merge changes brought with protocol version `70214` since by now all clients should be up to date.
- Added changes brought by DIP-29 to `MNLISTDIFF`