### PR TITLE
docs(dip28): add info to mn reward section

### DIFF
--- a/dip-0028.md
+++ b/dip-0028.md
@@ -280,9 +280,12 @@ type is 1:
 
 #### Changes in Masternode Rewards
 
-Since evonodes have 4 times more collateral than regular masternodes, it would not be fair to keep the
-masternode rewards as it is. Therefore, evonodes will be paid in four consecutive blocks each time they
-are selected for payment.
+##### Prior to Dash Platform release
+
+Since evonodes have 4 times more collateral than regular masternodes, it would not be fair to keep
+the masternode rewards as it is during the transition period where evonodes are enabled but Dash
+Platform has not been released. Therefore, evonodes will be paid in four consecutive blocks each
+time they are selected for payment.
 
 The following steps precede the existing algorithm described in
 [DIP-3](https://github.com/dashpay/dips/blob/master/dip-0003.md#masternode-rewards):
@@ -293,6 +296,12 @@ The following steps precede the existing algorithm described in
 4. Select the last evonode as payee and increment its consecutive payment state by one. Skip the
    remainder of the algorithm since the payee has been located.
 5. Continue with the current algorithm.
+
+##### After Dash Platform release
+
+Once Dash Platform is activated, evonodes will begin receiving the majority of their rewards
+directly from Dash Platform as described in the [Overview](#overview). At that point both regular
+masternodes and evonodes will receive a single reward per payment cycle from the Core chain.
 
 ### Simplified Masternode List entry
 


### PR DESCRIPTION
The original DIP didn't mentioned  rewards in the overview but didn't cover both stages (v19 / v20) in the actual masternode reward section. Relates to dashpay/dash-issues#38.