### PR TITLE
docs(dip27): update withdrawal safety to match v22

### DIFF
--- a/dip-0027.md
+++ b/dip-0027.md
@@ -142,11 +142,11 @@ Asset Unlock transactions might not be mined for multiple reasons. For example, 
 As a way to avoid a catastrophic failure if Platform is compromised, Core will limit credit pool withdrawals for at least the first release of Platform. The withdrawal limits may be re-evaluated and updated periodically as the system matures. To evaluate withdrawal validity, withdrawal amounts from the last 576 blocks should be tallied. The withdrawal should not be mined if:
 
 * It requests more DASH than the credit pool contains
-* The withdrawal would result in more than a 2000 DASH reduction in the credit pool over the 576 block-window
+* The withdrawal would result in more than a 2000 DASH reduction in the credit pool over the past 576 blocks
 
 Prior to activation of the `withdrawals` hard fork in Dash Core v22.0, more restrictive limits were followed. The withdrawal would not be mined if:
 
-* The withdrawal would result in more than a 1000 DASH reduction in the credit pool over the 576 block-window
+* The withdrawal would result in more than a 1000 DASH reduction in the credit pool over the past 576 blocks
 * The credit pool contains more than 1000 DASH, and the withdrawal would result in more than a 10% reduction in the credit pool over the 576-block window
 * The credit pool contains less than 1000 DASH, and the withdrawal would result in more than 100 DASH being removed from the pool over the 576-block window
 

--- a/dip-0027.md
+++ b/dip-0027.md
@@ -142,6 +142,10 @@ Asset Unlock transactions might not be mined for multiple reasons. For example, 
 As a way to avoid a catastrophic failure if Platform is compromised, Core will limit credit pool withdrawals for at least the first release of Platform. The withdrawal limits may be re-evaluated and updated periodically as the system matures. To evaluate withdrawal validity, withdrawal amounts from the last 576 blocks should be tallied. The withdrawal should not be mined if:
 
 * It requests more DASH than the credit pool contains
+* The withdrawal would result in more than a 2000 DASH reduction in the credit pool over the 576 block-window
+
+Prior to activation of the `withdrawals` hard fork in Dash Core v22.0, more restrictive limits were followed. The withdrawal would not be mined if:
+
 * The withdrawal would result in more than a 1000 DASH reduction in the credit pool over the 576 block-window
 * The credit pool contains more than 1000 DASH, and the withdrawal would result in more than a 10% reduction in the credit pool over the 576-block window
 * The credit pool contains less than 1000 DASH, and the withdrawal would result in more than 100 DASH being removed from the pool over the 576-block window


### PR DESCRIPTION
Dash Core v22 makes simplifies withdrawal safety rules and also makes them less restrictive as implemented in dashpay/dash#6369.