### PR TITLE
docs: convert remaining hpmn references to evonode

### DIFF
--- a/dip-0003.md
+++ b/dip-0003.md
@@ -329,9 +329,9 @@ The new system removes the need for masternode reward payment votes and allows t
 The new rules to determine the next block’s payee are:
 
 1. Take the last block's payee. If it is a regular masternode (type 0), go to step 5.
-2. If the last HPMN payee was already paid 4 blocks in a row, go to step 5.
-3. If the last HPMN is not present in the current masternode list anymore, go to step 5.
-4. Select last HPMN payee as the next block's payee. Return.
+2. If the last evonode payee was already paid 4 blocks in a row, go to step 5.
+3. If the last evonode is not present in the current masternode list anymore, go to step 5.
+4. Select last evonode payee as the next block's payee. Return.
 5. Take the valid masternode subset of the previous block
 6. Sort the set in ascending order by "testHeight" and “ProRegTx hash”. “testHeight” is determined for each individual entry and equals the “last paid height” (or “registered height” if the masternode was never paid). If the masternode was PoSe-banned before and revived later, the “revival height” of the masternode is used instead of the “registered height”. If the “testHeight” of two masternodes is identical, the ProRegTx hash acts as a deterministic tie breaker.
 7. Take the first entry of the resulting list and use this as the next block’s payee.

--- a/dip-0003/masternode-types.md
+++ b/dip-0003/masternode-types.md
@@ -3,4 +3,4 @@
 | Masternode Type | Description |
 | --- | --- |
 | 0 | Default (1000 DASH collateral) |
-| 1 | High Performance Masternode (HPMN) (4000 DASH collateral) |
+| 1 | Evolution masternode (evonode) (4000 DASH collateral) |

--- a/dip-0004.md
+++ b/dip-0004.md
@@ -110,7 +110,7 @@ Clients with protocol version greater than or equal to 70227 will receive the fo
 
 | Field               | Type | Size | Description                       |
 |---------------------| ---- | ---- |-----------------------------------|
-| type | uint_16 | 0 or 2 | Masternode type. 0 for regular masternode, 1 for HPMN. |
+| type | uint_16 | 0 or 2 | Masternode type. 0 for regular masternode, 1 for evonode. |
 | platformHTTPPort | uint_16 | 0 or 2 | TCP port of Platform HTTP/API interface (network byte order). Only present for masternode type 1. |
 | platformNodeID | byte[] | 0 or 20 | Dash Platform P2P node ID, derived from P2P public key. Only present for masternode type 1. |
 


### PR DESCRIPTION
Most HPMN references were previously updated in #145. This PR converts the remaining instances.