### PR TITLE
docs: document the extended addresses format in Appendix C of DIP-0003, add new {ProTx, SML} version to support it, add deprecation notices

### DIFF
--- a/dip-0003.md
+++ b/dip-0003.md
@@ -22,6 +22,7 @@
 1. [Masternode Rewards](#masternode-rewards)
 1. [Selecting Quorums](#selecting-quorums)
 1. [Appendix A: Reasons for Self Revocation of Operators](#appendix-a-reasons-for-self-revocation-of-operators)
+1. [Appendix B: Masternode Types](#appendix-b-masternode-types)
 1. [Copyright](#copyright)
 
 ## Special Mention
@@ -364,6 +365,10 @@ The individual quorum types present in Dash are not subject to this DIP and shou
 | 1 | Termination of Service |
 | 2 | Compromised Keys |
 | 3 | Change of Keys (Not compromised) |
+
+## Appendix B: Masternode Types
+
+See [masternode types table](dip-0003/masternode-types.md)
 
 ## Copyright
 

--- a/dip-0003.md
+++ b/dip-0003.md
@@ -268,11 +268,11 @@ Reorganisations of the chain must also correctly undo changes to the chain-tips 
 
 A ProRegTx is invalid if any of these conditions are true:
 
-In the case of type 0:
+In the case of default masternodes (type 0):
   1. collateralOutpoint `hash` is null but an output with 1000 DASH is not present at position `n` of the ProRegTx outputs
   2. collateralOutpoint `hash` is not null but an output with 1000 DASH can't be found in the UTXO specified by the `hash` and `n`
 
-In the case of type 1:
+In the case of EvoNodes (type 1):
   1. collateralOutpoint `hash` is null but an output with 4000 DASH is not present at position `n` of the ProRegTx outputs
   2. collateralOutpoint `hash` is not null but an output with 4000 DASH can't be found in the UTXO specified by the `hash` and `n`
 
@@ -330,9 +330,9 @@ The new system removes the need for masternode reward payment votes and allows t
 The new rules to determine the next block’s payee are:
 
 1. Take the last block's payee. If it is a regular masternode (type 0), go to step 5.
-2. If the last HPMN payee was already paid 4 blocks in a row, go to step 5.
-3. If the last HPMN is not present in the current masternode list anymore, go to step 5.
-4. Select last HPMN payee as the next block's payee. Return.
+2. If the last EvoNode (type 1) payee was already paid 4 blocks in a row, go to step 5.
+3. If the last EvoNode is not present in the current masternode list anymore, go to step 5.
+4. Select last EvoNode payee as the next block's payee. Return.
 5. Take the valid masternode subset of the previous block
 6. Sort the set in ascending order by "testHeight" and “ProRegTx hash”. “testHeight” is determined for each individual entry and equals the “last paid height” (or “registered height” if the masternode was never paid). If the masternode was PoSe-banned before and revived later, the “revival height” of the masternode is used instead of the “registered height”. If the “testHeight” of two masternodes is identical, the ProRegTx hash acts as a deterministic tie breaker.
 7. Take the first entry of the resulting list and use this as the next block’s payee.

--- a/dip-0003.md
+++ b/dip-0003.md
@@ -102,7 +102,7 @@ payloadSig must be empty.
 
 The ProRegTx might have the IP address and port fields set to zero. This will result in the masternode being added to the masternode list in the PoSe-banned state and require the operator to issue a ProUpServTx. This is needed in case the owner wants to delegate the operator role to a hosting service without knowing the IP Address and port in advance.
 
-The ProRegTx also defines the masternode's type and mode. Default masternodes are of type 0, and future types will be defined in an [annex document](dip-0003/masternode-types.md). Different types would introduce additional or different consensus rules towards the masternodes based on future Dash improvement proposals. Masternode types are not updatable, however each type can have multiple operation modes. The operation modes are updatable.
+The ProRegTx also defines the masternode's type and mode. Regular masternodes are of type 0, and future types will be defined in an [annex document](dip-0003/masternode-types.md). Different types would introduce additional or different consensus rules towards the masternodes based on future Dash improvement proposals. Masternode types are not updatable, however each type can have multiple operation modes. The operation modes are updatable.
 
 The ProRegTx also specifies the reward for the operator. The percentage of the masternode reward paid to the operator is calculated by dividing the operatorReward field by 100. When the field is set to zero, the owner will get the full reward for every block. If set to a non-zero value, the masternode operator may specify his operator reward payee script in a ProUpServTx. If he does not do so, the full reward goes to the masternode owner.
 
@@ -268,7 +268,7 @@ Reorganisations of the chain must also correctly undo changes to the chain-tips 
 
 A ProRegTx is invalid if any of these conditions are true:
 
-In the case of default masternodes (type 0):
+In the case of regular masternodes (type 0):
   1. collateralOutpoint `hash` is null but an output with 1000 DASH is not present at position `n` of the ProRegTx outputs
   2. collateralOutpoint `hash` is not null but an output with 1000 DASH can't be found in the UTXO specified by the `hash` and `n`
 

--- a/dip-0003.md
+++ b/dip-0003.md
@@ -23,6 +23,7 @@
 1. [Selecting Quorums](#selecting-quorums)
 1. [Appendix A: Reasons for Self Revocation of Operators](#appendix-a-reasons-for-self-revocation-of-operators)
 1. [Appendix B: Masternode Types](#appendix-b-masternode-types)
+1. [Appendix C: Network Information](#appendix-c-network-information)
 1. [Copyright](#copyright)
 
 ## Special Mention
@@ -100,7 +101,7 @@ This signature is only required for external collaterals. If collateralOutpoint 
 the fact that the ProRegTx was able to move the collateral acts as an implicit proof of ownership. In this case the
 payloadSig must be empty.
 
-The ProRegTx might have the IP address and port fields set to zero. This will result in the masternode being added to the masternode list in the PoSe-banned state and require the operator to issue a ProUpServTx. This is needed in case the owner wants to delegate the operator role to a hosting service without knowing the IP Address and port in advance.
+The ProRegTx might have the masternode network information field empty. This will result in the masternode being added to the masternode list in the PoSe-banned state and require the operator to issue a ProUpServTx. This is needed in case the owner wants to delegate the operator role to a hosting service without knowing the IP Address and port in advance.
 
 The ProRegTx also defines the masternode's type and mode. Regular masternodes are of type 0, and future types will be defined in an [annex document](dip-0003/masternode-types.md). Different types would introduce additional or different consensus rules towards the masternodes based on future Dash improvement proposals. Masternode types are not updatable, however each type can have multiple operation modes. The operation modes are updatable.
 
@@ -118,8 +119,7 @@ The transaction consists of the following data in the payload area:
 | type | uint_16 | 2 | Masternode type. Default set to 0. |
 | mode | uint_16 | 2 | Masternode mode. Default set to 0. |
 | collateralOutpoint | COutpoint | 36 | The collateral outpoint. |
-| ipAddress | byte[] | 16 | IPv6 address in network byte order. Only IPv4 mapped addresses are allowed (to be extended in the future) |
-| port | uint_16 | 2 | Port (network byte order) |
+| networkInfo | byte[] | variable | Masternode network information (see [appendix](#appendix-c-network-information)) |
 | KeyIdOwner | CKeyID | 20 | The public key hash used for owner related signing (ProTx updates, governance voting) |
 | PubKeyOperator | BLSPubKey | 48 | The public key used for operational related signing (network messages, ProTx updates) |
 | KeyIdVoting | CKeyID | 20 | The public key hash used for voting. |
@@ -146,7 +146,7 @@ There are multiple ways to update masternodes. The table below details the data 
 
 | Update Type | Transaction | Issued by | Data updated |
 | ----------- | ----------- | --------- | ------------ |
-| Service | ProUpServTx | Operator Only | IP Address / Port |
+| Service | ProUpServTx | Operator Only | Masternode Network Information |
 | Registration | ProUpRegTx | Owner Only | Mode / Payout Script / Voting Key / Operator Key |
 | Operator Revocation | ProUpRevTx | Operator Only | \* No data updated / * Only used to signal the owner that a new ProUpRegTx is required |
 
@@ -154,7 +154,7 @@ There are multiple ways to update masternodes. The table below details the data 
 
 To service update a masternode, the masternode operator must submit another special transaction (DIP2) to the network. This special transaction is called a Provider Update Service Transaction and is abbreviated as ProUpServTx. It can only be done by the operator.
 
-An operator can update the IP address and port fields of a masternode entry. If a non-zero operatorReward was set in the initial ProRegTx, the operator may also set the scriptOperatorPayout field in the ProUpServTx. If scriptOperatorPayout is not set and operatorReward is non-zero, the owner gets the full masternode reward.
+An operator can update the masternode network information of a masternode entry. If a non-zero operatorReward was set in the initial ProRegTx, the operator may also set the scriptOperatorPayout field in the ProUpServTx. If scriptOperatorPayout is not set and operatorReward is non-zero, the owner gets the full masternode reward.
 
 A ProUpServTx is only valid for masternodes in the registered masternodes subset. When processed, it updates the metadata of the masternode entry and revives the masternode if it was previously marked as PoSe-banned.
 
@@ -167,8 +167,7 @@ The transaction consists of the following data in the payload area:
 | version | uint_16 | 2 | ProUpServTx version number.  Set to 2 once v19 fork activates |
 | type | uint_16 | 0 or 2 | Masternode type. Only present for version 2. |
 | proTXHash | uint256 | 32 | The hash of the initial ProRegTx |
-| ipAddress | byte[] | 16 | IPv6 address in network byte order. Only IPv4 mapped addresses are allowed (to be extended in the future) |
-| port | uint_16 | 2 | Port (network byte order) |
+| networkInfo | byte[] | variable | Masternode network information (see [appendix](#appendix-c-network-information)) |
 | scriptOperatorPayoutSize | compactSize uint | 1-9 | Size of the Payee Script. |
 | scriptOperatorPayout | Script | Variable | Payee script (p2pkh/p2sh) |
 | inputsHash | uint256 | 32 | The SHA256 hash of all the outpoints of the transaction inputs |
@@ -247,7 +246,7 @@ Updating is done on the so called chain-tips list, which is the list valid at th
 
 The chain-tips list is updated for every new block that is processed. The rules to update the list are the following:
 
-  1. If a valid ProRegTx is encountered, a masternode entry (identified by the hash of the ProRegTx) is added to the registered set. The entry also contains metadata (IP address, public keys, etc.) found in the ProTx.
+  1. If a valid ProRegTx is encountered, a masternode entry (identified by the hash of the ProRegTx) is added to the registered set. The entry also contains metadata (masternode network information, public keys, etc.) found in the ProTx.
   2. If any transaction in the block spends the collateral of an existing entry in the registered masternode set, the corresponding masternode is removed from the list
   3. PoSe verification is performed for all masternodes in the valid subset. If the verification for a masternode fails, it is marked as PoSe-banned and thus will be excluded from the valid masternode subset. PoSe verification is defined by DIP 006 and only relies on data available on-chain up to the current chain-tip.
   4. If a ProUpServTx is found in the block and the referenced masternode is not marked as PoSe-banned, its metadata is updated.
@@ -281,14 +280,12 @@ Applicable to any type:
   2. KeyIdOwner or PubKeyOperator was already used by any entry in the registered masternodes set
   3. scriptPayout is not a P2PKH or P2SH script
   4. When scriptPayout is P2PKH script and the public key hash equals any of KeyIdOwner or KeyIdVoting
-  5. ipAddress is set and port is not set to the default mainnet port
-  6. ipAddress is set and not routable or not an IPv4 mapped address
-  7. ipAddress is set and already used in the registered masternodes set
-  8. operatorReward > 10000
-  9. The inputsHash does not match the calculated hash
-  10. collateralOutpoint `hash` is null and payloadSig is not empty (zero size)
-  11. collateralOutpoint `hash` is not null and payloadSig is not a valid signature signed with the collateral key
-  12. collateralOutpoint `hash` is not null and the referenced collateral is not a P2PKH output
+  5. networkInfo fails validation [(see rules)](dip-0003/network-info.md#mninfo_rules)
+  6. operatorReward > 10000
+  7. The inputsHash does not match the calculated hash
+  8. collateralOutpoint `hash` is null and payloadSig is not empty (zero size)
+  9. collateralOutpoint `hash` is not null and payloadSig is not a valid signature signed with the collateral key
+  10. collateralOutpoint `hash` is not null and the referenced collateral is not a P2PKH output
 
 Please note that while deploying DIP3, additional and temporary validation rules will apply. The details of these temporary rules will be described in the deployment plan.
 
@@ -297,13 +294,11 @@ Please note that while deploying DIP3, additional and temporary validation rules
 A ProUpServTx is invalid if any of these conditions are true:
 
   1. proTxHash can not be found in the registered masternode set
-  2. ipAddress is set and port is not set to the default mainnet port
-  3. ipAddress is set and not routable or not an IPv4 mapped address
-  4. ipAddress is set and already used in another masternode from the registered masternodes set
-  5. scriptOperatorPayout is set and operatorReward of the masternode is 0
-  6. scriptOperatorPayout is set and not a P2PKH or P2SH script
-  7. The inputsHash does not match the calculated hash
-  8. payloadSig is invalid
+  2. networkInfo fails validation [(see rules)](dip-0003/network-info.md#mninfo_rules)
+  3. scriptOperatorPayout is set and operatorReward of the masternode is 0
+  4. scriptOperatorPayout is set and not a P2PKH or P2SH script
+  5. The inputsHash does not match the calculated hash
+  6. payloadSig is invalid
 
 Please note that while deploying DIP3, additional and temporary validation rules will apply. The details of these temporary rules will be described in the deployment plan.
 
@@ -311,7 +306,7 @@ Please note that while deploying DIP3, additional and temporary validation rules
 
 A ProRegTx or ProUpServTx is invalid if any of these conditions are true (applicable only when type is 1):
 
-  1. platformP2PPort, platformHTTPPort and port from ipAddress are not distinct.
+  1. platformP2PPort, platformHTTPPort and networkInfo entries are not distinct.
   2. platformNodeID is null or is a non-hex string.
   3. platformNodeID is not unique in the network.
 
@@ -369,6 +364,10 @@ The individual quorum types present in Dash are not subject to this DIP and shou
 ## Appendix B: Masternode Types
 
 See [masternode types table](dip-0003/masternode-types.md)
+
+## Appendix C: Network Information
+
+Masternode network information is defined in the [appendix](dip-0003/network-info.md)
 
 ## Copyright
 

--- a/dip-0003.md
+++ b/dip-0003.md
@@ -101,7 +101,7 @@ This signature is only required for external collaterals. If collateralOutpoint 
 the fact that the ProRegTx was able to move the collateral acts as an implicit proof of ownership. In this case the
 payloadSig must be empty.
 
-The ProRegTx might have the masternode network information field empty. This will result in the masternode being added to the masternode list in the PoSe-banned state and require the operator to issue a ProUpServTx. This is needed in case the owner wants to delegate the operator role to a hosting service without knowing the IP Address and port in advance.
+The ProRegTx might have an empty masternode network information field. This will result in the masternode being added to the masternode list in the PoSe-banned state and require the operator to issue a ProUpServTx. This is needed in case the owner wants to delegate the operator role to a hosting service without knowing the IP Address and port in advance.
 
 The ProRegTx also defines the masternode's type and mode. Regular masternodes are of type 0, and future types will be defined in an [annex document](dip-0003/masternode-types.md). Different types would introduce additional or different consensus rules towards the masternodes based on future Dash improvement proposals. Masternode types are not updatable, however each type can have multiple operation modes. The operation modes are updatable.
 
@@ -128,8 +128,7 @@ The transaction consists of the following data in the payload area:
 | scriptPayout | Script | Variable | Payee script (p2pkh/p2sh) |
 | inputsHash | uint256 | 32 | The SHA256 hash of all the outpoints of the transaction inputs |
 | platformNodeID | byte[] | 0 or 20 | Dash Platform P2P node ID, derived from P2P public key. Only present for masternode type 1. |
-| platformP2PPort | uint_16 | 0 or 2 | TCP port of Dash Platform peer-to-peer communication between nodes (network byte order). Only present for masternode type 1. |
-| platformHTTPPort | uint_16 | 0 or 2 | TCP port of Platform HTTP/API interface (network byte order). Only present for masternode type 1. |
+| platformInfo | byte[] | variable | Platform network information (see [appendix](#appendix-c-network-information)) |
 | payloadSigSize | compactSize uint | 1-9 | Size of the Signature |
 | payloadSig | unsigned char[] | Variable | Signature of the hash of the ProTx fields. Signed with the key corresponding to the collateral outpoint in case the collateral is not part of the ProRegTx itself, empty otherwise. |
 
@@ -172,8 +171,7 @@ The transaction consists of the following data in the payload area:
 | scriptOperatorPayout | Script | Variable | Payee script (p2pkh/p2sh) |
 | inputsHash | uint256 | 32 | The SHA256 hash of all the outpoints of the transaction inputs |
 | platformNodeID | byte[] | 0 or 20 | Dash Platform P2P node ID, derived from P2P public key. Only present for masternode type 1. |
-| platformP2PPort | uint_16 | 0 or 2 | TCP port of Dash Platform peer-to-peer communication between nodes (network byte order). Only present for masternode type 1. |
-| platformHTTPPort | uint_16 | 0 or 2 | TCP port of Platform HTTP/API interface (network byte order). Only present for masternode type 1. |
+| platformInfo | byte[] | variable | Platform network information (see [appendix](#appendix-c-network-information)) |
 | payloadSig | BLSSig | 96 | Signature of the hash of the ProUpServTx fields. Signed by the Operator. |
 
 The different versions are:
@@ -306,7 +304,7 @@ Please note that while deploying DIP3, additional and temporary validation rules
 
 A ProRegTx or ProUpServTx is invalid if any of these conditions are true (applicable only when type is 1):
 
-  1. platformP2PPort, platformHTTPPort and networkInfo entries are not distinct.
+  1. platformInfo fails validation [(see rules)](dip-0003/network-info.md#plinfo_rules).
   2. platformNodeID is null or is a non-hex string.
   3. platformNodeID is not unique in the network.
 
@@ -367,7 +365,7 @@ See [masternode types table](dip-0003/masternode-types.md)
 
 ## Appendix C: Network Information
 
-Masternode network information is defined in the [appendix](dip-0003/network-info.md)
+Masternode and Platform network information are defined in the [appendix](dip-0003/network-info.md)
 
 ## Copyright
 

--- a/dip-0003.md
+++ b/dip-0003.md
@@ -128,16 +128,17 @@ The transaction consists of the following data in the payload area:
 | scriptPayout | Script | Variable | Payee script (p2pkh/p2sh) |
 | inputsHash | uint256 | 32 | The SHA256 hash of all the outpoints of the transaction inputs |
 | platformNodeID | byte[] | 0 or 20 | Dash Platform P2P node ID, derived from P2P public key. Only present for masternode type 1. |
-| platformInfo | byte[] | variable | Platform network information (see [appendix](#appendix-c-network-information)) |
+| platformInfo | byte[] | variable | Platform network information (see [appendix](#appendix-c-network-information)). Absent from version 3 onwards.  |
 | payloadSigSize | compactSize uint | 1-9 | Size of the Signature |
 | payloadSig | unsigned char[] | Variable | Signature of the hash of the ProTx fields. Signed with the key corresponding to the collateral outpoint in case the collateral is not part of the ProRegTx itself, empty otherwise. |
 
 The different versions are:
 
-| Version | Version Description                                  |
-|---------|------------------------------------------------------|
-| 1       | PubKeyOperator is serialised using legacy BLS scheme |
-| 2       | PubKeyOperator is serialised using basic BLS scheme  |
+| Version | Version Description                                                                          |
+|---------|----------------------------------------------------------------------------------------------|
+| 1       | PubKeyOperator is serialised using legacy BLS scheme                                         |
+| 2       | PubKeyOperator is serialised using basic BLS scheme                                          |
+| 3       | `networkInfo` uses the [extended addresses format](dip-0003/network-info.md#extended-format) |
 
 ## Updating Masternode Information
 
@@ -171,15 +172,16 @@ The transaction consists of the following data in the payload area:
 | scriptOperatorPayout | Script | Variable | Payee script (p2pkh/p2sh) |
 | inputsHash | uint256 | 32 | The SHA256 hash of all the outpoints of the transaction inputs |
 | platformNodeID | byte[] | 0 or 20 | Dash Platform P2P node ID, derived from P2P public key. Only present for masternode type 1. |
-| platformInfo | byte[] | variable | Platform network information (see [appendix](#appendix-c-network-information)) |
+| platformInfo | byte[] | variable | Platform network information (see [appendix](#appendix-c-network-information)). Absent from version 3 onwards. |
 | payloadSig | BLSSig | 96 | Signature of the hash of the ProUpServTx fields. Signed by the Operator. |
 
 The different versions are:
 
-| Version | Version Description                                  |
-|---------|------------------------------------------------------|
-| 1       | payloadSig is serialised using legacy BLS scheme |
-| 2       | payloadSig is serialised using basic BLS scheme and type is included in transaction |
+| Version | Version Description                                                                          |
+|---------|----------------------------------------------------------------------------------------------|
+| 1       | payloadSig is serialised using legacy BLS scheme                                             |
+| 2       | payloadSig is serialised using basic BLS scheme and type is included in transaction          |
+| 3       | `networkInfo` uses the [extended addresses format](dip-0003/network-info.md#extended-format) |
 
 ### Updating Registrar of Masternode (ProUpRegTx)
 
@@ -304,7 +306,7 @@ Please note that while deploying DIP3, additional and temporary validation rules
 
 A ProRegTx or ProUpServTx is invalid if any of these conditions are true (applicable only when type is 1):
 
-  1. platformInfo fails validation [(see rules)](dip-0003/network-info.md#plinfo_rules).
+  1. platformInfo, if required, fails validation [(see rules)](dip-0003/network-info.md#plinfo_rules).
   2. platformNodeID is null or is a non-hex string.
   3. platformNodeID is not unique in the network.
 
@@ -365,7 +367,8 @@ See [masternode types table](dip-0003/masternode-types.md)
 
 ## Appendix C: Network Information
 
-Masternode and Platform network information are defined in the [appendix](dip-0003/network-info.md)
+The extended network information format and the legacy network information fields (masternode and platform) it replaces
+are defined in the [appendix](dip-0003/network-info.md)
 
 ## Copyright
 

--- a/dip-0003.md
+++ b/dip-0003.md
@@ -280,7 +280,7 @@ Applicable to any type:
   2. KeyIdOwner or PubKeyOperator was already used by any entry in the registered masternodes set
   3. scriptPayout is not a P2PKH or P2SH script
   4. When scriptPayout is P2PKH script and the public key hash equals any of KeyIdOwner or KeyIdVoting
-  5. networkInfo fails validation [(see rules)](dip-0003/network-info.md#mninfo_rules)
+  5. networkInfo fails validation [(see rules)](dip-0003/network-info.md#extended-format)
   6. operatorReward > 10000
   7. The inputsHash does not match the calculated hash
   8. collateralOutpoint `hash` is null and payloadSig is not empty (zero size)
@@ -294,7 +294,7 @@ Please note that while deploying DIP3, additional and temporary validation rules
 A ProUpServTx is invalid if any of these conditions are true:
 
   1. proTxHash can not be found in the registered masternode set
-  2. networkInfo fails validation [(see rules)](dip-0003/network-info.md#mninfo_rules)
+  2. networkInfo fails validation [(see rules)](dip-0003/network-info.md#extended-format)
   3. scriptOperatorPayout is set and operatorReward of the masternode is 0
   4. scriptOperatorPayout is set and not a P2PKH or P2SH script
   5. The inputsHash does not match the calculated hash

--- a/dip-0003/masternode-types.md
+++ b/dip-0003/masternode-types.md
@@ -1,6 +1,6 @@
 # Appendix B: Masternode Types
 
-| Masternode Type | Description                        | Collateral |
-| --------------- | ---------------------------------- | ---------- |
-| 0               | Default                            | 1000 DASH  |
-| 1               | High Performance Masternode (HPMN) | 4000 DASH  |
+| Masternode Type | Description                    | Collateral |
+| --------------- | ------------------------------ | ---------- |
+| 0               | Default                        | 1000 DASH  |
+| 1               | Evolution Masternode (EvoNode) | 4000 DASH  |

--- a/dip-0003/masternode-types.md
+++ b/dip-0003/masternode-types.md
@@ -2,5 +2,5 @@
 
 | Masternode Type | Description                    | Collateral |
 | --------------- | ------------------------------ | ---------- |
-| 0               | Default                        | 1000 DASH  |
+| 0               | Regular                        | 1000 DASH  |
 | 1               | Evolution Masternode (EvoNode) | 4000 DASH  |

--- a/dip-0003/masternode-types.md
+++ b/dip-0003/masternode-types.md
@@ -1,6 +1,6 @@
-# Masternode Types
+# Appendix B: Masternode Types
 
-| Masternode Type | Description |
-| --- | --- |
-| 0 | Default (1000 DASH collateral) |
-| 1 | High Performance Masternode (HPMN) (4000 DASH collateral) |
+| Masternode Type | Description                        | Collateral |
+| --------------- | ---------------------------------- | ---------- |
+| 0               | Default                            | 1000 DASH  |
+| 1               | High Performance Masternode (HPMN) | 4000 DASH  |

--- a/dip-0003/network-info.md
+++ b/dip-0003/network-info.md
@@ -185,9 +185,15 @@ DNS records for a domain name MUST have a valid `A` or `AAAA` entry.
 * This field MUST have a string containing at least two labels separated by the specified delimiter.
   * "Dotless domains" (as described by [RFC 7085](https://datatracker.ietf.org/doc/html/rfc7085#section-2)) MUST NOT be
     permitted.
+* This field MUST NOT permit top level domains associated with private/internal networks, including but not limited to,
+  the TLD assigned by [RFC 6762](https://datatracker.ietf.org/doc/html/rfc6762#section-3) for multicast DNS, alternatives
+  to it enumerated in [Appendix G](https://datatracker.ietf.org/doc/html/rfc6762#appendix-G) or the special-use domain
+  assigned by [RFC 8375](https://datatracker.ietf.org/doc/html/rfc8375).
 
 # References
 
 * [BIP 0155: addrv2 message](https://github.com/bitcoin/bips/blob/17c04f9fa1ecae173d6864b65717e13dfc1880af/bip-0155.mediawiki)
 * [RFC 1035: Domain Names - Implementation and Specification](https://datatracker.ietf.org/doc/html/rfc1035)
+* [RFC 6762: Multicast DNS](https://datatracker.ietf.org/doc/html/rfc6762)
 * [RFC 7085: Top-Level Domains That Are Already Dotless](https://datatracker.ietf.org/doc/html/rfc7085)
+* [RFC 8375: Special-Use Domain 'home.arpa.'](https://datatracker.ietf.org/doc/html/rfc8375)

--- a/dip-0003/network-info.md
+++ b/dip-0003/network-info.md
@@ -26,10 +26,10 @@ The fields below are represented as `networkInfo` and are applicable to all mast
 The fields below are represented as `platformInfo` and are only applicable for EvoNodes as defined in
 [Appendix B](masternode-types.md)
 
-| Field            | Type    | Size   | Description                                                                              |
-| ---------------- | ------- | ------ | ---------------------------------------------------------------------------------------- |
-| platformP2PPort  | uint_16 | 0 or 2 | TCP port of Dash Platform peer-to-peer communication between nodes (network byte order). |
-| platformHTTPPort | uint_16 | 0 or 2 | TCP port of Platform HTTP/API interface (network byte order).                            |
+| Field            | Type    | Size   | Description                                                         |
+| ---------------- | ------- | ------ | ------------------------------------------------------------------- |
+| platformP2PPort  | uint_16 | 0 or 2 | TCP port of Dash Platform peer-to-peer communication between nodes. |
+| platformHTTPPort | uint_16 | 0 or 2 | TCP port of Platform HTTP/API interface.                            |
 
 ### <a name="plinfo_rules">Validation Rules</a>
 

--- a/dip-0003/network-info.md
+++ b/dip-0003/network-info.md
@@ -53,7 +53,6 @@ The fields below are represented as `networkInfo` and are applicable to all mast
 | ------- | ------- | -------- | ---------------------------------------------------------------------------------------- |
 | count   | uint_8  | 1        | Number of addresses through which the masternode is accessible                           |
 | entries | byte[]  | variable | Array of length `count` containing network information used to connect to the masternode |
-| port    | uint_16 | 2        | Port (network byte order)                                                                |
 
 ### `count` field
 
@@ -79,10 +78,11 @@ This field is an array of [`count`](#count-field) elements of type [`entry`](#en
 
 #### `entry` type
 
-| Field   | Type   | Size     | Description                                                     |
-| ------- | ------ | -------- | --------------------------------------------------------------- |
-| type    | uint_8 | 1        | Network identifier                                              |
-| address | byte[] | variable | Address of `type` that can be used to connect to the masternode |
+| Field   | Type    | Size     | Description                                                     |
+| ------- | ------- | -------- | --------------------------------------------------------------- |
+| type    | uint_8  | 1        | Network identifier                                              |
+| address | byte[]  | variable | Address of `type` that can be used to connect to the masternode |
+| port    | uint_16 | 2        | Port (network byte order)                                       |
 
 #### `entry.type` field
 
@@ -116,7 +116,7 @@ The network identifier field MUST support the following [extensions](#extensions
 * `address` of [`type`](#entrytype-field)s originating from [extensions](#extensions) MUST be compliant with the
   specification as defined (e.g. [Internet domain names](#extension-a-internet-domain-names))
 
-### `port` field
+#### `entry.port` field
 
 * This field MUST be any integer between 1024 and 65535.
 
@@ -150,8 +150,12 @@ The network identifier field MUST support the following [extensions](#extensions
 
   </details>
 
-* This field MUST be ignored for connecting to [`entry.address`](#entryaddress-field) of [`entry.type`](#entrytype-field)
-  where ports are immaterial.
+* This field MUST be set to `0` if the port number is immaterial for the [`type`](#entrytype-field) of [`address`](#entryaddress-field)
+  and MUST be ignored when attempting to make a connection. Listed are the [`type`](#entrytype-field)s where the port number is immaterial.
+
+  | Network ID | Description                             |
+  | ---------- | --------------------------------------- |
+  | `0x05`     | I2P overlay network address             |
 
 ## Extensions
 

--- a/dip-0003/network-info.md
+++ b/dip-0003/network-info.md
@@ -98,6 +98,14 @@ The network identifier field MUST comply with the following table of BIP 155 [ne
 | `0x06`     | 16                     | CJDNS overlay network address           | Yes     |
 | `0x07`     | 16                     | Yggdrasil overlay network address       | No      |
 
+The network identifier field MUST support the following [extensions](#extensions):
+
+| Network ID | Address Length (bytes) | Description                            | Support |
+| ---------- | ---------------------- | -------------------------------------- | ------- |
+| `0xD0`     | variable               | Domain name (globally routed internet) | Yes     |
+
+* Network IDs not enumerated in the above tables MUST NOT be permitted
+
 #### `entry.address` field
 
 * [`address`](#entryaddress-field) of [`type`](#entrytype-field)s originating from BIP 155 MUST be compliant with
@@ -105,6 +113,8 @@ The network identifier field MUST comply with the following table of BIP 155 [ne
   [TorV3](https://github.com/bitcoin/bips/blob/17c04f9fa1ecae173d6864b65717e13dfc1880af/bip-0155.mediawiki#appendix-b-tor-v3-address-encoding),
   [I2P](https://github.com/bitcoin/bips/blob/17c04f9fa1ecae173d6864b65717e13dfc1880af/bip-0155.mediawiki#appendix-c-i2p-address-encoding),
   [CJDNS](https://github.com/bitcoin/bips/blob/17c04f9fa1ecae173d6864b65717e13dfc1880af/bip-0155.mediawiki#appendix-d-cjdns-address-encoding)).
+* `address` of [`type`](#entrytype-field)s originating from [extensions](#extensions) MUST be compliant with the
+  specification as defined (e.g. [Internet domain names](#extension-a-internet-domain-names))
 
 ### `port` field
 
@@ -143,6 +153,41 @@ The network identifier field MUST comply with the following table of BIP 155 [ne
 * This field MUST be ignored for connecting to [`entry.address`](#entryaddress-field) of [`entry.type`](#entrytype-field)
   where ports are immaterial.
 
+## Extensions
+
+Extensions are supported types of addresses that are beyond the types enumerated in BIP 155. Their network IDs are defined
+in the [`entry.type`](#entrytype-field) extensions table.
+
+### Extension A: Internet domain names
+
+Domain names resolved by DNS on the globally routed internet have the following [`entry.address`](#entryaddress-field) structure
+
+| Field   | Type   | Size     | Description                                                     |
+| ------- | ------ | -------- | --------------------------------------------------------------- |
+| size    | uint_8 | 1        | Length of the domain name in bytes                              |
+| name    | byte[] | variable | Domain name encoded in US-ASCII                                 |
+
+DNS records for a domain name MUST have a valid `A` or `AAAA` entry.
+
+#### `size` field
+
+* This field MUST hold a value of at least 4
+* This field MUST NOT hold a value greater than 253 pursuant to [RFC 1035](https://datatracker.ietf.org/doc/html/rfc1035#section-2.3.4),
+  taking into consideration the leading and trailing bytes as specified in [Section 3.1](https://datatracker.ietf.org/doc/html/rfc1035#section-3.1)
+
+#### `name` field
+
+* This field MUST only permit letters, digits and a hyphen (`-`) in each label pursuant to
+  [RFC 1035](https://datatracker.ietf.org/doc/html/rfc1035#section-2.3.1).
+  * A label is defined as a string of 63 characters or less beginning with a letter and ending with a letter or number
+    separated by the period (`.`) delimiter.
+* This field MUST NOT permit upper-case letters despite being permitted by RFC 1035 in light of its case-insensitivity.
+* This field MUST have a string containing at least two labels separated by the specified delimiter.
+  * "Dotless domains" (as described by [RFC 7085](https://datatracker.ietf.org/doc/html/rfc7085#section-2)) MUST NOT be
+    permitted.
+
 # References
 
 * [BIP 0155: addrv2 message](https://github.com/bitcoin/bips/blob/17c04f9fa1ecae173d6864b65717e13dfc1880af/bip-0155.mediawiki)
+* [RFC 1035: Domain Names - Implementation and Specification](https://datatracker.ietf.org/doc/html/rfc1035)
+* [RFC 7085: Top-Level Domains That Are Already Dotless](https://datatracker.ietf.org/doc/html/rfc7085)

--- a/dip-0003/network-info.md
+++ b/dip-0003/network-info.md
@@ -65,22 +65,27 @@ This field is an array of [`p_count`](#p_count-field) elements of type [`p_entry
 * `p_entries[0]`
     * MUST have [`purpose`](#p_entrypurpose-field) code `CORE_P2P`
     * MUST be registered regardless of masternode type (as defined in [Appendix B](masternode-types.md)).
-    * [`entries[0]`](#p_entryentries-field) MUST have a [`type`](#entrytype-field) of `0x01` (IPv4 address).
-    * On mainnet, [`entries[0]`](#p_entryentries-field) MUST use [`port`](#entryport-field) of `9999`.
+    * [`entries[0]`](#p_entryentries-field):
+      * MUST have a [`type`](#entrytype-field) of `0x01` (IPv4 address).
+      * On mainnet, MUST use [`port`](#entryport-field) of `9999`.
     * [`entries`](#p_entryentries-field) MUST NOT have a [`type`](#entrytype-field) of `0xD0` (domain name).
 * `p_entries[1]`
     * MUST have [`purpose`](#p_entrypurpose-field) code `PLATFORM_P2P`.
     * MUST be registered for EvoNodes (type 1).
     * MUST NOT be registered for regular masternodes (type 0).
-    * [`entries[0]`](#p_entryentries-field) MUST have a [`type`](#entrytype-field) of `0x01` (IPv4 address).
-    * On mainnet, [`entries[0]`](#p_entryentries-field) MUST use [`port`](#entryport-field) of `26656`.
+    * [`entries[0]`](#p_entryentries-field):
+      * MUST have a [`type`](#entrytype-field) of `0x01` (IPv4 address).
+      * MUST have the same [`address`](#entryaddress-field) as `p_entries[0][0]`
+      * On mainnet, MUST use [`port`](#entryport-field) of `26656`.
     * [`entries`](#p_entryentries-field) MUST NOT have a [`type`](#entrytype-field) of `0xD0` (domain name).
 * `p_entries[2]`
     * MUST have [`purpose`](#p_entrypurpose-field) code `PLATFORM_HTTPS`.
     * MUST be registered for EvoNodes (type 1).
     * MUST NOT be registered for regular masternodes (type 0).
-    * [`entries[0]`](#p_entryentries-field) MUST have a [`type`](#entrytype-field) of `0x01` (IPv4 address).
-    * On mainnet, [`entries[0]`](#p_entryentries-field) MUST use [`port`](#entryport-field) of `443`.
+    * [`entries[0]`](#p_entryentries-field):
+      * MUST have a [`type`](#entrytype-field) of `0x01` (IPv4 address).
+      * MUST have the same [`address`](#entryaddress-field) as `p_entries[0][0]`
+      * On mainnet, MUST use [`port`](#entryport-field) of `443`.
     * [`entries`](#p_entryentries-field) MAY have a [`type`](#entrytype-field) of `0xD0` (domain name).
       * The element's [`address`](#entryaddress-field) MUST resolve to any [`address`](#entryaddress-field) in
         `p_entries[1]` of [`type`](#entrytype-field) `0x01` (IPv4 address) or `0x02` (IPv6 address)

--- a/dip-0003/network-info.md
+++ b/dip-0003/network-info.md
@@ -1,0 +1,22 @@
+# Appendix C: Network Information
+
+## Masternode Information
+
+The fields below are represented as `networkInfo` and are applicable to all masternodes types as defined in
+[Appendix B](masternode-types.md)
+
+| Field     | Type    | Size | Description                                                                |
+| --------- | ------- | ---- | -------------------------------------------------------------------------- |
+| ipAddress | byte[]  | 16   | IPv6 address in network byte order. Only IPv4 mapped addresses are allowed |
+| port      | uint_16 | 2    | Port (network byte order)                                                  |
+
+### <a name="mninfo_rules">Validation Rules</a>
+
+* `ipAddress` MUST be a valid IPv4 address that is routable on the global internet
+* `ipAddress` MUST NOT be already used in the registered masternodes set
+* `port` MUST be within the valid port range [1, 65535]
+* On mainnet, `port` MUST be set to the following value
+
+  | Field  | Value  |
+  | -------| ------ |
+  | port   | 9999   |

--- a/dip-0003/network-info.md
+++ b/dip-0003/network-info.md
@@ -20,3 +20,24 @@ The fields below are represented as `networkInfo` and are applicable to all mast
   | Field  | Value  |
   | -------| ------ |
   | port   | 9999   |
+
+## Platform Information
+
+The fields below are represented as `platformInfo` and are only applicable for EvoNodes as defined in
+[Appendix B](masternode-types.md)
+
+| Field            | Type    | Size   | Description                                                                              |
+| ---------------- | ------- | ------ | ---------------------------------------------------------------------------------------- |
+| platformP2PPort  | uint_16 | 0 or 2 | TCP port of Dash Platform peer-to-peer communication between nodes (network byte order). |
+| platformHTTPPort | uint_16 | 0 or 2 | TCP port of Platform HTTP/API interface (network byte order).                            |
+
+### <a name="plinfo_rules">Validation Rules</a>
+
+* `platformP2PPort` and `platformHTTPPort` MUST be within the valid port range [1, 65535]
+* `platformP2PPort`, `platformHTTPPort`, and [`port`](#masternode-information) from `networkInfo` MUST be distinct
+* On mainnet, `platformP2PPort` and `platformHTTPPort` MUST be set to the following values
+
+  | Field              | Value  |
+  | ------------------ | ------ |
+  | platformP2PPort    | 26656  |
+  | platformHTTPPort   | 443    |

--- a/dip-0003/network-info.md
+++ b/dip-0003/network-info.md
@@ -1,6 +1,8 @@
 # Appendix C: Network Information
 
-## Masternode Information
+## Legacy Format
+
+### Masternode Information
 
 The fields below are represented as `networkInfo` and are applicable to all masternodes types as defined in
 [Appendix B](masternode-types.md)
@@ -10,7 +12,7 @@ The fields below are represented as `networkInfo` and are applicable to all mast
 | ipAddress | byte[]  | 16   | IPv6 address in network byte order. Only IPv4 mapped addresses are allowed |
 | port      | uint_16 | 2    | Port (network byte order)                                                  |
 
-### <a name="mninfo_rules">Validation Rules</a>
+#### <a name="mninfo_rules">Validation Rules</a>
 
 * `ipAddress` MUST be a valid IPv4 address that is routable on the global internet
 * `ipAddress` MUST NOT be already used in the registered masternodes set
@@ -21,7 +23,7 @@ The fields below are represented as `networkInfo` and are applicable to all mast
   | -------| ------ |
   | port   | 9999   |
 
-## Platform Information
+### Platform Information
 
 The fields below are represented as `platformInfo` and are only applicable for EvoNodes as defined in
 [Appendix B](masternode-types.md)
@@ -31,7 +33,7 @@ The fields below are represented as `platformInfo` and are only applicable for E
 | platformP2PPort  | uint_16 | 0 or 2 | TCP port of Dash Platform peer-to-peer communication between nodes. |
 | platformHTTPPort | uint_16 | 0 or 2 | TCP port of Platform HTTP/API interface.                            |
 
-### <a name="plinfo_rules">Validation Rules</a>
+#### <a name="plinfo_rules">Validation Rules</a>
 
 * `platformP2PPort` and `platformHTTPPort` MUST be within the valid port range [1, 65535]
 * `platformP2PPort`, `platformHTTPPort`, and [`port`](#masternode-information) from `networkInfo` MUST be distinct
@@ -41,3 +43,76 @@ The fields below are represented as `platformInfo` and are only applicable for E
   | ------------------ | ------ |
   | platformP2PPort    | 26656  |
   | platformHTTPPort   | 443    |
+
+## Extended Format
+
+The fields below are represented as `networkInfo` and are applicable to all masternodes types as defined in
+[Appendix B](masternode-types.md).
+
+| Field   | Type    | Size     | Description                                                                              |
+| ------- | ------- | -------- | ---------------------------------------------------------------------------------------- |
+| count   | uint_8  | 1        | Number of addresses through which the masternode is accessible                           |
+| entries | byte[]  | variable | Array of length `count` containing network information used to connect to the masternode |
+| port    | uint_16 | 2        | Port (network byte order)                                                                |
+
+### `count` field
+
+* The value of this field MUST correspond to the number of [`entry`](#entry-type) elements in the
+  [`entries`](#entries-field) field.
+
+### `entries` field
+
+This field is an array of [`count`](#count-field) elements of type [`entry`](#entry-type) where:
+
+* There MUST be at least one element and at most thirty-two elements.
+
+* `entries[0]` MUST have a [`type`](#entrytype-field) of `0x01` (IPv4 address).
+
+* On mainnet, `entries[0]` must be set to the following value
+
+  | Field  | Value  |
+  | -------| ------ |
+  | port   | 9999   |
+
+* Elements in `entries` MUST allow duplicate [`type`](#entrytype-field)s but MUST NOT allow duplicate
+  [`address`](#entryaddress-field)es irrespective of associated [`type`](#entrytype-field).
+
+#### `entry` type
+
+| Field   | Type   | Size     | Description                                                     |
+| ------- | ------ | -------- | --------------------------------------------------------------- |
+| type    | uint_8 | 1        | Network identifier                                              |
+| address | byte[] | variable | Address of `type` that can be used to connect to the masternode |
+
+#### `entry.type` field
+
+The network identifier field MUST comply with the following table of BIP 155 [network IDs](https://github.com/bitcoin/bips/blob/17c04f9fa1ecae173d6864b65717e13dfc1880af/bip-0155.mediawiki#specification):
+
+| Network ID | Address Length (bytes) | Description                             | Support |
+| ---------- | ---------------------- | --------------------------------------- | ------- |
+| `0x01`     | 4                      | IPv4 address (globally routed internet) | Yes     |
+| `0x02`     | 16                     | IPv6 address (globally routed internet) | Yes     |
+| `0x03`     | 10                     | Tor v2 hidden service address           | No      |
+| `0x04`     | 32                     | Tor v3 hidden service address           | Yes     |
+| `0x05`     | 32                     | I2P overlay network address             | Yes     |
+| `0x06`     | 16                     | CJDNS overlay network address           | Yes     |
+| `0x07`     | 16                     | Yggdrasil overlay network address       | No      |
+
+#### `entry.address` field
+
+* [`address`](#entryaddress-field) of [`type`](#entrytype-field)s originating from BIP 155 MUST be compliant with
+  encoding standards as defined by BIP 155 (e.g.
+  [TorV3](https://github.com/bitcoin/bips/blob/17c04f9fa1ecae173d6864b65717e13dfc1880af/bip-0155.mediawiki#appendix-b-tor-v3-address-encoding),
+  [I2P](https://github.com/bitcoin/bips/blob/17c04f9fa1ecae173d6864b65717e13dfc1880af/bip-0155.mediawiki#appendix-c-i2p-address-encoding),
+  [CJDNS](https://github.com/bitcoin/bips/blob/17c04f9fa1ecae173d6864b65717e13dfc1880af/bip-0155.mediawiki#appendix-d-cjdns-address-encoding)).
+
+### `port` field
+
+* This field MUST be any integer between 1024 and 65535.
+
+* This field MUST be ignored for connecting to [`entry.address`](#entryaddress-field) of [`entry.type`](#entrytype-field)
+  where ports are immaterial.
+
+# References
+
+* [BIP 0155: addrv2 message](https://github.com/bitcoin/bips/blob/17c04f9fa1ecae173d6864b65717e13dfc1880af/bip-0155.mediawiki)

--- a/dip-0003/network-info.md
+++ b/dip-0003/network-info.md
@@ -110,6 +110,36 @@ The network identifier field MUST comply with the following table of BIP 155 [ne
 
 * This field MUST be any integer between 1024 and 65535.
 
+* This field MUST NOT permit a value considered "prohibited" (see below)
+
+  <details>
+
+  <summary>Prohibited ports:</summary>
+
+  | Port Number | Description                           |
+  | ----------- | ------------------------------------- |
+  | 1719        | H.323 registration                    |
+  | 1720        | H.323 call signaling                  |
+  | 1723        | Point-to-Point Tunneling Protocol     |
+  | 2049        | Network File System                   |
+  | 3659        | Apple SASL                            |
+  | 4045        | NFS lock daemon                       |
+  | 5060        | Session Initiation Protocol (SIP)     |
+  | 5061        | SIP over TLS                          |
+  | 6000        | X11                                   |
+  | 6566        | Scanner Access Now Easy (SANE) daemon |
+  | 6665-6666   | Internet Relay Chat (Unofficial)      |
+  | 6667        | IRC (Official)                        |
+  | 6668-6669   | IRC (Unofficial)                      |
+  | 6697        | IRC over TLS (Official)               |
+  | 8332        | Bitcoin JSON-RPC server               |
+  | 8333        | Bitcoin P2P                           |
+  | 10080       | Amanda                                |
+  | 18332       | Bitcoin JSON-RPC server (Testnet)     |
+  | 18333       | Bitcoin P2P (Testnet)                 |
+
+  </details>
+
 * This field MUST be ignored for connecting to [`entry.address`](#entryaddress-field) of [`entry.type`](#entrytype-field)
   where ports are immaterial.
 

--- a/dip-0004.md
+++ b/dip-0004.md
@@ -110,7 +110,7 @@ Clients with protocol version greater than or equal to 70227 will receive the fo
 
 | Field               | Type | Size | Description                       |
 |---------------------| ---- | ---- |-----------------------------------|
-| type | uint_16 | 0 or 2 | Masternode type. 0 for regular masternode, 1 for HPMN. |
+| type | uint_16 | 0 or 2 | Masternode type. 0 for regular masternode, 1 for EvoNode. |
 | platformHTTPPort | uint_16 | 0 or 2 | TCP port of Platform HTTP/API interface (network byte order). Only present for masternode type 1. |
 | platformNodeID | byte[] | 0 or 20 | Dash Platform P2P node ID, derived from P2P public key. Only present for masternode type 1. |
 

--- a/dip-0004.md
+++ b/dip-0004.md
@@ -105,17 +105,17 @@ A SML entry consists of the following fields:
 | pubKeyOperator   | BLSPubKey | 48       | The operators public key                                                                          | _Not applicable_                                  |
 | keyIDVoting      | CKeyID    | 20       | The public key hash used for voting.                                                              | _Not applicable_                                  |
 | isValid          | bool      | 1        | True if a masternode is not PoSe-banned                                                           | _Not applicable_                                  |
-| type             | uint_16   | 0 or 2   | Masternode type. 0 for regular masternode, 1 for EvoNode.                                         | `PROTOCOL_VERSION` >= `70227` and `nVersion` == 2 |
+| type             | uint_16   | 0 or 2   | Masternode type. 0 for regular masternode, 1 for EvoNode.                                         | `PROTOCOL_VERSION` >= `70227` and `nVersion` >= 2 |
 | platformHTTPPort | uint_16   | 0 or 2   | TCP port of Platform HTTP/API interface (network byte order). Only present for masternode type 1. | `PROTOCOL_VERSION` >= `70227` and `nVersion` == 2 |
-| platformNodeID   | byte[]    | 0 or 20  | Dash Platform P2P node ID, derived from P2P public key. Only present for masternode type 1.       | `PROTOCOL_VERSION` >= `70227` and `nVersion` == 2 |
+| platformNodeID   | byte[]    | 0 or 20  | Dash Platform P2P node ID, derived from P2P public key. Only present for masternode type 1.       | `PROTOCOL_VERSION` >= `70227` and `nVersion` >= 2 |
 
+The `nVersion` field indicates indicates the following:
 
-The `nVersion` field indicates which BLS scheme is used to serialise each SML entries' `pubKeyOperator` field.
-
-| Version | Value Description                                         |
-| ------- | --------------------------------------------------------- |
-| 1       | Serialisation of `pubKeyOperator` using legacy BLS scheme |
-| 2       | Serialisation of `pubKeyOperator` using basic BLS scheme  |
+| Version | Value Description                                                                            |
+| ------- | -------------------------------------------------------------------------------------------- |
+| 1       | Serialisation of `pubKeyOperator` using legacy BLS scheme                                    |
+| 2       | Serialisation of `pubKeyOperator` using basic BLS scheme                                     |
+| 3       | `networkInfo` uses the [extended addresses format](dip-0003/network-info.md#extended-format) |
 
 ### Calculating the merkle root of the active LLMQs
 

--- a/dip-0004.md
+++ b/dip-0004.md
@@ -100,8 +100,7 @@ A SML entry consists of the following fields:
 | --- | --- | --- | --- |
 | proRegTxHash | uint256 | 32 | The hash of the ProRegTx that identifies the masternode |
 | confirmedHash | uint256 | 32 | The hash of the block at which the masternode got confirmed |
-| ipAddress | byte[] | 16 | IPv6 address in network byte order. Only IPv4 mapped addresses are allowed (to be extended in the future) |
-| port | uint_16 | 2 | Port (network byte order) |
+| networkInfo | byte[] | variable | Masternode network information (see [appendix](dip-0003.md#appendix-c-network-information)) |
 | pubKeyOperator | BLSPubKey | 48 | The operators public key |
 | keyIDVoting | CKeyID | 20 | The public key hash used for voting. |
 | isValid | bool | 1 | True if a masternode is not PoSe-banned |

--- a/dip-0004.md
+++ b/dip-0004.md
@@ -96,38 +96,26 @@ A SML entry is used to calculate the hashes for the merkleRootMNList. It is also
 
 A SML entry consists of the following fields:
 
-| Field | Type | Size | Description |
-| --- | --- | --- | --- |
-| proRegTxHash | uint256 | 32 | The hash of the ProRegTx that identifies the masternode |
-| confirmedHash | uint256 | 32 | The hash of the block at which the masternode got confirmed |
-| networkInfo | byte[] | variable | Masternode network information (see [appendix](dip-0003.md#appendix-c-network-information)) |
-| pubKeyOperator | BLSPubKey | 48 | The operators public key |
-| keyIDVoting | CKeyID | 20 | The public key hash used for voting. |
-| isValid | bool | 1 | True if a masternode is not PoSe-banned |
+| Field            | Type      | Size     | Description                                                                                       | Presence condition                                |
+| ---------------- | --------- | -------- | ------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
+| nVersion         | uint16_t  | 2        | Version of the SML entry                                                                          | `PROTOCOL_VERSION` >= `70228`                     |
+| proRegTxHash     | uint256   | 32       | The hash of the ProRegTx that identifies the masternode                                           | _Not applicable_                                  |
+| confirmedHash    | uint256   | 32       | The hash of the block at which the masternode got confirmed                                       | _Not applicable_                                  |
+| networkInfo      | byte[]    | variable | Masternode network information (see [appendix](dip-0003.md#appendix-c-network-information))       | _Not applicable_                                  |
+| pubKeyOperator   | BLSPubKey | 48       | The operators public key                                                                          | _Not applicable_                                  |
+| keyIDVoting      | CKeyID    | 20       | The public key hash used for voting.                                                              | _Not applicable_                                  |
+| isValid          | bool      | 1        | True if a masternode is not PoSe-banned                                                           | _Not applicable_                                  |
+| type             | uint_16   | 0 or 2   | Masternode type. 0 for regular masternode, 1 for EvoNode.                                         | `PROTOCOL_VERSION` >= `70227` and `nVersion` == 2 |
+| platformHTTPPort | uint_16   | 0 or 2   | TCP port of Platform HTTP/API interface (network byte order). Only present for masternode type 1. | `PROTOCOL_VERSION` >= `70227` and `nVersion` == 2 |
+| platformNodeID   | byte[]    | 0 or 20  | Dash Platform P2P node ID, derived from P2P public key. Only present for masternode type 1.       | `PROTOCOL_VERSION` >= `70227` and `nVersion` == 2 |
 
-Clients with protocol version greater than or equal to 70227 will receive the following fields just after `isValid`.
-
-| Field               | Type | Size | Description                       |
-|---------------------| ---- | ---- |-----------------------------------|
-| type | uint_16 | 0 or 2 | Masternode type. 0 for regular masternode, 1 for EvoNode. |
-| platformHTTPPort | uint_16 | 0 or 2 | TCP port of Platform HTTP/API interface (network byte order). Only present for masternode type 1. |
-| platformNodeID | byte[] | 0 or 20 | Dash Platform P2P node ID, derived from P2P public key. Only present for masternode type 1. |
-
-The new `type`, `platformHTTPPort` and `platformNodeID` fields will be serialised only when v19 activates and only for entries with `nVersion` equals to 2.
-
-Clients with protocol version greater than or equal to 70228 will receive the following field just before `proRegTxHash`.
-
-| Field               | Type     | Size | Description                       |
-|---------------------| -------- | ---- |-----------------------------------|
-| nVersion            | uint16_t | 2    | Version of the SML entry          |
 
 The `nVersion` field indicates which BLS scheme is used to serialise each SML entries' `pubKeyOperator` field.
 
-| Version | Value Description                                       |
-|---------|-----------------------------------------------------------|
+| Version | Value Description                                         |
+| ------- | --------------------------------------------------------- |
 | 1       | Serialisation of `pubKeyOperator` using legacy BLS scheme |
 | 2       | Serialisation of `pubKeyOperator` using basic BLS scheme  |
-
 
 ### Calculating the merkle root of the active LLMQs
 

--- a/dip-0028.md
+++ b/dip-0028.md
@@ -310,7 +310,7 @@ clients, a `version` field is added to the `MNLISTDIFF` message between `cbTx` a
 | --- | --- | --- | --- |
 | version | uint_16 | 2 | Version of the `MNLISTDIFF` reply |
 
-Second, in the case of version 2 `MNLISTDIFF` messages, all SML entries will contain a new type
+Second, in the case of version 2 or greater `MNLISTDIFF` messages, all SML entries will contain a new type
 field describing the type of the corresponding masternode.  The `type` field is serialized after the
 `isValid` field. If the `type` is 1 (evonode) then the `platformHTTPPort` and `platformNodeID` fields
 are serialized after the `type` field.
@@ -319,7 +319,7 @@ are serialized after the `type` field.
 | --- | --- | --- | --- | --- |
 | type | uint_16 | 0 or 2 bytes | Masternode type. 0 for regular masternode, 1 for evonode. | Upon activation of this DIP. Only when `version` is 2. |
 | platformHTTPPort | uint_16 | 0 or 2 bytes | TCP port of Platform HTTP/API interface (network byte order). Only present for masternode type 1. | Only when `version` is 2 and `type` is 1. |
-| platformNodeID | byte[] | 0 or 20 bytes | Dash Platform node ID, derived from P2P public key. Only present for masternode type 1. | Only when `version` is 2 and `type` is 1. |
+| platformNodeID | byte[] | 0 or 20 bytes | Dash Platform node ID, derived from P2P public key. Only present for masternode type 1. | Only when `version` is equal to or greater than 2 and `type` is 1. |
 
 #### Changes in calculating the Merkle root of the Masternode list
 

--- a/dip-0028.md
+++ b/dip-0028.md
@@ -231,15 +231,13 @@ type 1 requires a 4000 DASH collateral.
 
 A ProRegTx with masternode type 1 indicates registration of a 4000 DASH collateral evonode.
 
-If the `version` is 2 and the `type` is 1, then the `platformNodeID`, `platformP2PPort`, and
-`platformHTTPPort` fields are serialized in that order between the `inputsHash` and `payloadSigSize`
-fields.
+If the `version` is 2 and the `type` is 1, then the `platformNodeID` and `platformInfo`
+fields are serialized in that order between the `inputsHash` and `payloadSigSize` fields.
 
 | Field | Type | Size | Description | Serialized |
 | --- | --- | --- | --- | --- |
 | platformNodeID | byte[] | 0 or 20 bytes | Dash Platform node ID, derived from P2P public key. Only present for masternode type 1. | Only when `version` is 2 and `type` is 1. |
-| platformP2PPort | uint_16 | 0 or 2 bytes | TCP port of Dash Platform peer-to-peer communication between nodes (network byte order). Only present for masternode type 1. | Only when `version` is 2 and `type` is 1. |
-| platformHTTPPort | uint_16 | 0 or 2 bytes | TCP port of Platform HTTP/API interface (network byte order). Only present for masternode type 1. | Only when `version` is 2 and `type` is 1. |
+| platformInfo | byte[] | variable | Platform network information (see [appendix](dip-0003.md#appendix-c-network-information)). Only present for masternode type 1. | Only when `version` is 2 and `type` is 1. |
 
 #### Changes in ProUpServTx
 
@@ -247,16 +245,14 @@ Since the ProUpServTx does not currently include the `type` field, version 2 of 
 it and serializes it right after the `version` field. A ProUpServTx of masternode type 1 indicates
 an update registrar of a 4000 Dash collateral evonode.
 
-Also, if the `version` is 2 and the `type` is 1, then the `platformNodeID`, `platformP2PPort`, and
-`platformHTTPPort` fields are serialized in that order between the `inputsHash` and `payloadSig`
-fields.
+Also, if the `version` is 2 and the `type` is 1, then the `platformNodeID` and `platformInfo`
+fields are serialized in that order between the `inputsHash` and `payloadSig` fields.
 
 | Field | Type | Size | Description | Serialized |
 | --- | --- | --- | --- | --- |
 | type | uint_16 | 0 or 2 bytes | Masternode type. 0 for regular masternode, 1 for evonode. | Only when `version` is 2. |
 | platformNodeID | byte[] | 0 or 20 bytes | Dash Platform node ID, derived from P2P public key. Only present for masternode type 1. | Only when `version` is 2 and `type` is 1. |
-| platformP2PPort | uint_16 | 0 or 2 bytes | TCP port of Dash Platform peer-to-peer communication between nodes (network byte order). Only present for masternode type 1. | Only when `version` is 2 and `type` is 1. |
-| platformHTTPPort | uint_16 | 0 or 2 bytes | TCP port of Platform HTTP/API interface (network byte order). Only present for masternode type 1. | Only when `version` is 2 and `type` is 1. |
+| platformInfo | byte[] | variable | Platform network information (see [appendix](dip-0003.md#appendix-c-network-information)). Only present for masternode type 1. | Only when `version` is 2 and `type` is 1. |
 
 #### Added validation rules
 
@@ -270,11 +266,7 @@ The following new ProRegTx rules are added and are only applicable when `type` i
 The following new rules are added for both ProRegTx and ProUpServTx and are only applicable when
 type is 1:
 
-* `platformP2PPort` and `platformHTTPPort` MUST be valid port values [1, 65535]
-* `platformP2PPort`, `platformHTTPPort`, and `port` from `networkInfo` MUST be distinct
-* For mainnet evonodes, `platformP2PPort` and `platformHTTPPort` MUST be set to the default values
-  * Default Platform P2P port: 26656
-  * Default Platform HTTP port: 443
+* `platformInfo` MUST pass validation [(see rules)](dip-0003/network-info.md#plinfo_rules).
 * `platformNodeID` MUST be a non-empty Hex string
 * `platformNodeID` MUST be unique network-wide
 

--- a/dip-0028.md
+++ b/dip-0028.md
@@ -271,7 +271,7 @@ The following new rules are added for both ProRegTx and ProUpServTx and are only
 type is 1:
 
 * `platformP2PPort` and `platformHTTPPort` MUST be valid port values [1, 65535]
-* `platformP2PPort`, `platformHTTPPort`, and port from ipAddress MUST be distinct
+* `platformP2PPort`, `platformHTTPPort`, and `port` from `networkInfo` MUST be distinct
 * For mainnet evonodes, `platformP2PPort` and `platformHTTPPort` MUST be set to the default values
   * Default Platform P2P port: 26656
   * Default Platform HTTP port: 443

--- a/dip-0028.md
+++ b/dip-0028.md
@@ -229,6 +229,11 @@ type 1 requires a 4000 DASH collateral.
 
 #### Changes in ProRegTx
 
+> [!WARNING]
+> The field `platformInfo` is deprecated with the implementation of extended addresses as defined
+> in [Appendix C](dip-0003/network-info.md#extended-format) of DIP 0003. The information given below
+> is provided to document historical behavior.
+
 A ProRegTx with masternode type 1 indicates registration of a 4000 DASH collateral evonode.
 
 If the `version` is 2 and the `type` is 1, then the `platformNodeID` and `platformInfo`
@@ -240,6 +245,11 @@ fields are serialized in that order between the `inputsHash` and `payloadSigSize
 | platformInfo | byte[] | variable | Platform network information (see [appendix](dip-0003.md#appendix-c-network-information)). Only present for masternode type 1. | Only when `version` is 2 and `type` is 1. |
 
 #### Changes in ProUpServTx
+
+> [!WARNING]
+> The field `platformInfo` is deprecated with the implementation of extended addresses as defined
+> in [Appendix C](dip-0003/network-info.md#extended-format) of DIP 0003. The information given below
+> is provided to document historical behavior.
 
 Since the ProUpServTx does not currently include the `type` field, version 2 of the transaction adds
 it and serializes it right after the `version` field. A ProUpServTx of masternode type 1 indicates
@@ -255,6 +265,11 @@ fields are serialized in that order between the `inputsHash` and `payloadSig` fi
 | platformInfo | byte[] | variable | Platform network information (see [appendix](dip-0003.md#appendix-c-network-information)). Only present for masternode type 1. | Only when `version` is 2 and `type` is 1. |
 
 #### Added validation rules
+
+> [!WARNING]
+> The field `platformInfo` is deprecated with the implementation of extended addresses as defined
+> in [Appendix C](dip-0003/network-info.md#extended-format) of DIP 0003. The information given below
+> is provided to document historical behavior.
 
 The following new ProRegTx rules are added and are only applicable when `type` is 1:
 


### PR DESCRIPTION
## Additional Information

* Depends on https://github.com/dashpay/dips/pull/162

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated masternode network information fields to use a unified `networkInfo` format, replacing separate IP address and port fields.
  * Added detailed appendices describing masternode types and the new network information format, supporting extended address types and validation rules.
  * Revised terminology for masternode types and reward selection logic for clarity.
  * Marked `platformInfo` as deprecated and updated related validation and serialization rules.
  * Consolidated and clarified field presence and versioning in the Simplified Masternode List (SML) documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->