### PR TITLE
ci: add lint action

### DIFF
--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -1,4 +1,4 @@
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   lint:

--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -13,7 +13,7 @@ jobs:
         files: '**/*.md'
         separator: ","
     - uses: DavidAnson/markdownlint-cli2-action@v20
-      if: steps.changed-files.outputs.any_changed == 'true'
+      # if: steps.changed-files.outputs.any_changed == 'true'
       with:
         config: '.markdownlint.json'
         globs: '**/*.md'

--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -1,0 +1,20 @@
+on: [push, pull_request]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - uses: tj-actions/changed-files@v46
+      id: changed-files
+      with:
+        files: '**/*.md'
+        separator: ","
+    - uses: DavidAnson/markdownlint-cli2-action@v20
+      if: steps.changed-files.outputs.any_changed == 'true'
+      with:
+        config: '.markdownlint.json'
+        globs: ${{ steps.changed-files.outputs.all_changed_files }}
+        separator: ","

--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -13,9 +13,9 @@ jobs:
         files: '**/*.md'
         separator: ","
     - uses: DavidAnson/markdownlint-cli2-action@v20
-      # if: steps.changed-files.outputs.any_changed == 'true'
+      if: steps.changed-files.outputs.any_changed == 'true'
       with:
         config: '.markdownlint.json'
-        globs: '**/*.md'
-        # globs: ${{ steps.changed-files.outputs.all_changed_files }}
+        # globs: '**/*.md'
+        globs: ${{ steps.changed-files.outputs.all_changed_files }}
         separator: ","

--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -16,5 +16,6 @@ jobs:
       if: steps.changed-files.outputs.any_changed == 'true'
       with:
         config: '.markdownlint.json'
-        globs: ${{ steps.changed-files.outputs.all_changed_files }}
+        globs: '**/*.md'
+        # globs: ${{ steps.changed-files.outputs.all_changed_files }}
         separator: ","

--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -14,6 +14,7 @@ jobs:
         separator: ","
     - uses: DavidAnson/markdownlint-cli2-action@v20
       if: steps.changed-files.outputs.any_changed == 'true'
+      continue-on-error: true
       with:
         config: '.markdownlint.json'
         # globs: '**/*.md'


### PR DESCRIPTION
Checks against the lint rules in https://github.com/dashpay/dips/blob/master/.markdownlint.json. Only checks changed files for now and "passes" even if lint identified.

Example run: https://github.com/thephez/dips/actions/runs/15164078202