### PR TITLE
docs: lint fixes

### DIFF
--- a/dip-0006.md
+++ b/dip-0006.md
@@ -182,16 +182,16 @@ The internal Dash message name is `qcontrib` and the format of the message is:
 
 | Field | Type | Size | Description |
 |--|--|--|--|
-| llmqType | uint8_t | 1 | The LLMQ type
-| quorumHash | uint256 | 32 | The quorum identifier
-| proTxHash | uint256 | 32 | The proTxHash of the contributing member
-| vvecSize | compactSize uint | 1-9 | The size of the verification vector
-| vvec | BLSPubKey[] | 48 * vvecSize | The verification vector
-| ephemeralPubKey | BLSPubKey | 48 | Ephemeral BLS public key used to encrypt secret key contributions
-| ivSeed | uint256 | 32 | Seed used to create the AES initialization vectors for all members
-| skCount | compactSize uint | 1-9 | Number of encrypted secret key contributions
-| skContributions | byte[] | 32 * skCount | Secret key contributions encrypted to recipient masternodes’ BLS public operator key
-| sig | BLSSig | 96 | BLS signature, signed with the operator key of the contributing masternode
+| llmqType | uint8_t | 1 | The LLMQ type |
+| quorumHash | uint256 | 32 | The quorum identifier |
+| proTxHash | uint256 | 32 | The proTxHash of the contributing member |
+| vvecSize | compactSize uint | 1-9 | The size of the verification vector |
+| vvec | BLSPubKey[] | 48 * vvecSize | The verification vector |
+| ephemeralPubKey | BLSPubKey | 48 | Ephemeral BLS public key used to encrypt secret key contributions |
+| ivSeed | uint256 | 32 | Seed used to create the AES initialization vectors for all members |
+| skCount | compactSize uint | 1-9 | Number of encrypted secret key contributions |
+| skContributions | byte[] | 32 * skCount | Secret key contributions encrypted to recipient masternodes’ BLS public operator key |
+| sig | BLSSig | 96 | BLS signature, signed with the operator key of the contributing masternode |
 
 ### 3. Complaining phase
 
@@ -225,14 +225,14 @@ The internal Dash message name is `qcomplaint` and the format of the message is:
 
 | Field | Type | Size | Description |
 |--|--|--|--|
-| llmqType | uint8_t | 1 | The LLMQ type
-| quorumHash | uint256 | 32 | The quorum identifier
-| proTxHash | uint256 | 32 | The proTxHash of the complaining member
-| badBitSize | compactSize uint | 1-9 | Number of bits in the bad members bitvector
-| badMembers | byte[] | (badBitSize + 7) / 8 | The bad members bitvector
-| complaintsBitSize | compactSize uint | 1-9 | Number of bits in the complaints bitvector
-| complaints | byte[] | (complaintsBitSize + 7) / 8 | The complaints bitvector
-| sig | BLSSig | 96 | BLS signature, signed with the operator key of the contributing masternode
+| llmqType | uint8_t | 1 | The LLMQ type |
+| quorumHash | uint256 | 32 | The quorum identifier |
+| proTxHash | uint256 | 32 | The proTxHash of the complaining member |
+| badBitSize | compactSize uint | 1-9 | Number of bits in the bad members bitvector |
+| badMembers | byte[] | (badBitSize + 7) / 8 | The bad members bitvector |
+| complaintsBitSize | compactSize uint | 1-9 | Number of bits in the complaints bitvector |
+| complaints | byte[] | (complaintsBitSize + 7) / 8 | The complaints bitvector |
+| sig | BLSSig | 96 | BLS signature, signed with the operator key of the contributing masternode |
 
 ### 4. Justification phase
 
@@ -260,12 +260,12 @@ The internal Dash message name is `qjustify` and the format of the message is:
 
 | Field | Type | Size | Description |
 |--|--|--|--|
-| llmqType | uint8_t | 1 | The LLMQ type
-| quorumHash | uint256 | 32 | The quorum identifier
-| proTxHash | uint256 | 32 | The proTxHash of the justifying member
-| skCount | compactSize uint | 1-9 | Number of unencrypted secret key contributions
-| skContributions | pair(uint32[], BLSSecKey[]) | (4 + 32) * skCount |  Unencrypted secret key contributions with indexes of the corresponding members
-| sig | BLSSig | 96 | BLS signature, signed with the operator key of the contributing masternode
+| llmqType | uint8_t | 1 | The LLMQ type |
+| quorumHash | uint256 | 32 | The quorum identifier |
+| proTxHash | uint256 | 32 | The proTxHash of the justifying member |
+| skCount | compactSize uint | 1-9 | Number of unencrypted secret key contributions |
+| skContributions | pair(uint32[], BLSSecKey[]) | (4 + 32) * skCount |  Unencrypted secret key contributions with indexes of the corresponding members |
+| sig | BLSSig | 96 | BLS signature, signed with the operator key of the contributing masternode |
 
 ### 5. Commitment phase
 
@@ -304,15 +304,15 @@ The internal Dash message name is `qpcommit` and the format of the message is:
 
 | Field | Type | Size | Description |
 |--|--|--|--|
-| llmqType | uint8_t | 1 | The LLMQ type
-| quorumHash | uint256 | 32 | The quorum identifier
-| proTxHash | uint256 | 32 | The proTxHash of the committing member
-| validMembersSize | compactSize uint | 1-9 | Bit size of the validMembers bitvector
-| validMembers | byte[] | (validMembersSize + 7) / 8 | Bitset of valid members in this commitment
-| quorumPublicKey | BLSPubKey | 48 | The quorum public key
-| quorumVvecHash | uint256 | 32 | The SHA256 hash of the quorum verification vector
-| quorumSig | BLSSig | 96 | Threshold signature, signed with the threshold signature share of the committing member
-| sig | BLSSig | 96 | BLS signature, signed with the operator key of the contributing masternode
+| llmqType | uint8_t | 1 | The LLMQ type |
+| quorumHash | uint256 | 32 | The quorum identifier |
+| proTxHash | uint256 | 32 | The proTxHash of the committing member |
+| validMembersSize | compactSize uint | 1-9 | Bit size of the validMembers bitvector |
+| validMembers | byte[] | (validMembersSize + 7) / 8 | Bitset of valid members in this commitment |
+| quorumPublicKey | BLSPubKey | 48 | The quorum public key |
+| quorumVvecHash | uint256 | 32 | The SHA256 hash of the quorum verification vector |
+| quorumSig | BLSSig | 96 | Threshold signature, signed with the threshold signature share of the committing member |
+| sig | BLSSig | 96 | BLS signature, signed with the operator key of the contributing masternode |
 
 ### 6. Finalization phase
 
@@ -349,34 +349,34 @@ The internal Dash message name is `qfcommit` and the format of the message is:
 
 | Field | Type | Size | Description |
 |--|--|--|--|
-| version | uint16_t | 2 | Version of the final commitment message
-| llmqType | uint8_t | 1 | [Type of LLMQ](#current-llmq-types)
-| quorumHash | uint256 | 32 | The quorum identifier
-| signersSize | compactSize uint | 1-9 | Bit size of the signers bitvector
-| signers | byte[] | (signersSize + 7) / 8 | Bitset representing the aggregated signers of this final commitment
-| validMembersSize | compactSize uint | 1-9 | Bit size of the validMembers bitvector
-| validMembers | byte[] | (validMembersSize + 7) / 8 | Bitset of valid members in this commitment
-| quorumPublicKey | BLSPubKey | 48 | The quorum public key
-| quorumVvecHash | uint256 | 32 | The SHA256 hash of the quorum verification vector
-| quorumSig | BLSSig | 96 | Recovered threshold signature
-| sig | BLSSig | 96 | Aggregated BLS signatures from all included commitments
+| version | uint16_t | 2 | Version of the final commitment message |
+| llmqType | uint8_t | 1 | [Type of LLMQ](#current-llmq-types) |
+| quorumHash | uint256 | 32 | The quorum identifier |
+| signersSize | compactSize uint | 1-9 | Bit size of the signers bitvector |
+| signers | byte[] | (signersSize + 7) / 8 | Bitset representing the aggregated signers of this final commitment |
+| validMembersSize | compactSize uint | 1-9 | Bit size of the validMembers bitvector |
+| validMembers | byte[] | (validMembersSize + 7) / 8 | Bitset of valid members in this commitment |
+| quorumPublicKey | BLSPubKey | 48 | The quorum public key |
+| quorumVvecHash | uint256 | 32 | The SHA256 hash of the quorum verification vector |
+| quorumSig | BLSSig | 96 | Recovered threshold signature |
+| sig | BLSSig | 96 | Aggregated BLS signatures from all included commitments |
 
 `qfcommit` with version 2 or 4 include the `quorumIndex` field highlighted below as described in the [DIP24 Quorum Composition section](dip-0024.md#quorum-composition):
 
 | Field | Type | Size | Description |
 |--|--|--|--|
-| version | uint16_t | 2 | Version of the final commitment message
-| llmqType | uint8_t | 1 | [Type of LLMQ](#current-llmq-types)
-| quorumHash | uint256 | 32 | The quorum identifier
+| version | uint16_t | 2 | Version of the final commitment message |
+| llmqType | uint8_t | 1 | [Type of LLMQ](#current-llmq-types) |
+| quorumHash | uint256 | 32 | The quorum identifier |
 | **quorumIndex** | **int16_t** | **2** | **The quorum index** |
-| signersSize | compactSize uint | 1-9 | Bit size of the signers bitvector
-| signers | byte[] | (signersSize + 7) / 8 | Bitset representing the aggregated signers of this final commitment
-| validMembersSize | compactSize uint | 1-9 | Bit size of the validMembers bitvector
-| validMembers | byte[] | (validMembersSize + 7) / 8 | Bitset of valid members in this commitment
-| quorumPublicKey | BLSPubKey | 48 | The quorum public key
-| quorumVvecHash | uint256 | 32 | The SHA256 hash of the quorum verification vector
-| quorumSig | BLSSig | 96 | Recovered threshold signature
-| sig | BLSSig | 96 | Aggregated BLS signatures from all included commitments
+| signersSize | compactSize uint | 1-9 | Bit size of the signers bitvector |
+| signers | byte[] | (signersSize + 7) / 8 | Bitset representing the aggregated signers of this final commitment |
+| validMembersSize | compactSize uint | 1-9 | Bit size of the validMembers bitvector |
+| validMembers | byte[] | (validMembersSize + 7) / 8 | Bitset of valid members in this commitment |
+| quorumPublicKey | BLSPubKey | 48 | The quorum public key |
+| quorumVvecHash | uint256 | 32 | The SHA256 hash of the quorum verification vector |
+| quorumSig | BLSSig | 96 | Recovered threshold signature |
+| sig | BLSSig | 96 | Aggregated BLS signatures from all included commitments |
 
 After v19 fork activation, `quorumPublicKey`, `quorumSig` and `sig` will be serialised using the basic BLS scheme.
 The `version` field indicates which scheme to use for BLS serialisation so the existing chain containing keys/signatures serialised with the legacy scheme can continue to be synced properly.
@@ -418,8 +418,8 @@ The format of the "quorum commitment" special TX payload with type=6 is:
 | Field | Type | Size | Description |
 |--|--|--|--|
 | version | uint_16 | 2 | Commitment special transaction version number.  Currently set to 1. Please note that this is not the same as the version field of qfcommit |
-| height | uint32_t | 4 | The height of the block in which this commitment is included
-| commitment | qfcommit | Variable | This equals the payload of the "qfcommit" P2P message
+| height | uint32_t | 4 | The height of the block in which this commitment is included |
+| commitment | qfcommit | Variable | This equals the payload of the "qfcommit" P2P message |
 
 ## Active LLMQ sets
 

--- a/dip-0014.md
+++ b/dip-0014.md
@@ -265,7 +265,6 @@ m/
 * Ext Pub : dptp1C5gGd8NzvAke5WNKyRfpDRyvV2UZ3jjrZVZU77qk9yZemMGSdZpkWp7y6wt3FzvFxAHSW8VMCaC1p6Ny5EqWuRm2sjvZLUUFMMwXhmW6eS69qjX958RYBH5R8bUCGZkCfUyQ8UVWcx9katkrRr
 * Ext Priv : dpts1vgMVEs9mmv1YLwURCeoTn9CFMZ8JMVhyZuxQSKttNSETR3zydMFHMKTTNDQPf6nnupCCtcNnSu3nKZXAJhaguyoJWD4Ju5PE6PSkBqAKWci7HLz37qmFmZZU6GMkLvNLtST2iV8NmqqbX37c45
 
-
 ## Test Vector 4
 
 Mnemonic : birth kingdom trash renew flavor utility donkey gasp regular alert pave layer
@@ -286,6 +285,7 @@ m/
 * Key : b898ad92d3a0698bc3117d3777d82676673816ce52f4fc2f1263a2f676825f90
 * Ext Pub : dptp1CLkexeadp6guoi8Fbiwq6CLZm3hT1DJLwHsxWvwYSeAhjenFhcQ9HumZSftfZEr4dyQjFD7gkM5bSn6Aj7F1Jve8KTn4JsMEaj9dFyJkYs4Ga5HSUqeajxGVmzaY1pEioDmvUtZL3J1NCDCmzQ
 * Ext Priv : dpts1vwRsaPMQfqwp59ELpx5UeuYtdaMCJyGTwiGtr8zgf6qWPMWnhPpg8R73hwR1xLibbdKVdh17zfwMxFEMxZzBKUgPwvuosUGDKW4ayZjs3AQB9EGRcVpDoFT8V6nkcc6KzksmZxvmDcd3MqiPEu
+
 # Copyright
 
 Copyright (c) 2020 Dash Core Group, Inc. [Licensed under the MIT

--- a/dip-0021.md
+++ b/dip-0021.md
@@ -89,32 +89,32 @@ payload:
 
 | Field | Type | Size | Description |
 | - | - | - | - |
-| quorumType | uint8 | 1 byte | Type of the quorum the data is about.
-| quorumHash | uint256 | 32 bytes | Hash of the quorum the data is about.
-| dataMask | uint16 | 2 bytes | See [Available data flags](#available-data-flags). This value should be equal to the `dataMask` value of the requesting `QGETDATA` message.
-| protxHash | uint256 | 32 bytes | This is the protx hash of the member which can decrypt the data in `data_0002`. Included if _0x0002_ is set in `dataMask`.
-| error | uint8 | 1 byte | See [Possible error codes](#possible-error-codes)
-| data_0001 | BLSVerificationVector | Variable | Included if _0x0001_ is set in `dataMask`. See [Available data flags](#available-data-flags).
-| data_0002 | std::vector&lt;CBLSIESEncryptedObject&lt;CBLSSecretKey>> | Variable | Included if _0x0002_ is set in `dataMask`. See [Available data flags](#available-data-flags).
+| quorumType | uint8 | 1 byte | Type of the quorum the data is about. |
+| quorumHash | uint256 | 32 bytes | Hash of the quorum the data is about. |
+| dataMask | uint16 | 2 bytes | See [Available data flags](#available-data-flags). This value should be equal to the `dataMask` value of the requesting `QGETDATA` message. |
+| protxHash | uint256 | 32 bytes | This is the protx hash of the member which can decrypt the data in `data_0002`. Included if _0x0002_ is set in `dataMask`. |
+| error | uint8 | 1 byte | See [Possible error codes](#possible-error-codes) |
+| data_0001 | BLSVerificationVector | Variable | Included if _0x0001_ is set in `dataMask`. See [Available data flags](#available-data-flags). |
+| data_0002 | std::vector&lt;CBLSIESEncryptedObject&lt;CBLSSecretKey>> | Variable | Included if _0x0002_ is set in `dataMask`. See [Available data flags](#available-data-flags). |
 
 ## Available data flags
 
 | Flag | Description | Response |
 | - | - | - |
-| _0x0001_ | Request the quorum verification vector of the LLMQ. | The quorum verification vector of the LLMQ.<p><p>**Type**: _std::vector&lt;CBLSPublicKey>_<p>**Size**: &lt;quorum_threshold> * 48 bytes<p>**Max. size**: ~16,320 bytes
-| _0x0002_ | Request all encrypted DKG contributions directed to the member with the protx hash provided in the _protxHash_ field. | Set of secret keys encrypted with the operator key of the requesting masternode.<p><p>**Type**: std::vector&lt;<em>CBLSIESEncryptedObject&lt;CBLSSecretKey>></em><p>**Size**: <valid_member_count> * 112 bytes<p>**Max. Size**: 44,800 bytes
+| _0x0001_ | Request the quorum verification vector of the LLMQ. | The quorum verification vector of the LLMQ.<p><p>**Type**: _std::vector&lt;CBLSPublicKey>_<p>**Size**: &lt;quorum_threshold> * 48 bytes<p>**Max. size**: ~16,320 bytes |
+| _0x0002_ | Request all encrypted DKG contributions directed to the member with the protx hash provided in the _protxHash_ field. | Set of secret keys encrypted with the operator key of the requesting masternode.<p><p>**Type**: std::vector&lt;<em>CBLSIESEncryptedObject&lt;CBLSSecretKey>></em><p>**Size**: <valid_member_count> * 112 bytes<p>**Max. Size**: 44,800 bytes |
 
 ## Possible error codes
 
 | Value | Name | Description |
 | - | - | - |
-| _0x00_ | _NONE_ | No error, this value indicates the `QGETDATA` request was processed successfully.
-| _0x01_ | _QUORUM_TYPE_INVALID_ | The quorum type provided in the `quorumType` field is invalid.
-| _0x02_ | _QUORUM_BLOCK_NOT_FOUND_ | The hash provided in the `quorumHash` field wasn’t found in the active chain.
-| _0x03_ | _QUORUM_NOT_FOUND_ | The quorum (combination of `quorumType` and `quorumHash`) wasn’t found in the active chain.
-| _0x04_ | _MASTERNODE_IS_NO_MEMBER_ | The masternode with the protx-hash provided in the `protxHash` field is not a valid member of the requested quorum.
-| _0x05_ | _QUORUM_VERIFICATION_VECTOR_MISSING_ | The quorum verification vector for the requested quorum is missing on the node servicing the request.
-| _0x06_ | _ENCRYPTED_CONTRIBUTIONS_MISSING_ | The encrypted DKG contributions for the requested member are missing on the node servicing the request.
+| _0x00_ | _NONE_ | No error, this value indicates the `QGETDATA` request was processed successfully. |
+| _0x01_ | _QUORUM_TYPE_INVALID_ | The quorum type provided in the `quorumType` field is invalid. |
+| _0x02_ | _QUORUM_BLOCK_NOT_FOUND_ | The hash provided in the `quorumHash` field wasn’t found in the active chain. |
+| _0x03_ | _QUORUM_NOT_FOUND_ | The quorum (combination of `quorumType` and `quorumHash`) wasn’t found in the active chain. |
+| _0x04_ | _MASTERNODE_IS_NO_MEMBER_ | The masternode with the protx-hash provided in the `protxHash` field is not a valid member of the requested quorum. |
+| _0x05_ | _QUORUM_VERIFICATION_VECTOR_MISSING_ | The quorum verification vector for the requested quorum is missing on the node servicing the request. |
+| _0x06_ | _ENCRYPTED_CONTRIBUTIONS_MISSING_ | The encrypted DKG contributions for the requested member are missing on the node servicing the request. |
 
 # Processing and usage
 
@@ -123,8 +123,8 @@ data. The following table shows the steps required depending on the _dataType_ r
 
 | dataType | Validate and process the data | Usage |
 | - | - | - |
-| _0x0001_ | Calculate the hash of the received quorum verification vector. The calculated hash must match `quorumvvecHash` from the mined commitment of the LLMQ the data has been requested for. | Mainly used to make the quorum verification vector of other LLMQs available on platform validators. Another use case is described in “Usage” of the flag _0x0002_ below.
-| 0x0002 | Decrypt all the contributions with the operator key, aggregate them to the secret key share and make sure its public key matches the public key share calculated with the quorum verification vector for the masternode’s `protxHash`. | This can be wrapped into a workflow where a masternode which is a member of one or more quorums has lost its LLMQ DKG data. By requesting _0x0002_ it can recover its secret key share. When combined with _0x0001_, it can recover itself as a valid member of the LLMQ by just asking other LLMQ-Members for the required data after a re-sync/re-index.
+| _0x0001_ | Calculate the hash of the received quorum verification vector. The calculated hash must match `quorumvvecHash` from the mined commitment of the LLMQ the data has been requested for. | Mainly used to make the quorum verification vector of other LLMQs available on platform validators. Another use case is described in “Usage” of the flag _0x0002_ below. |
+| 0x0002 | Decrypt all the contributions with the operator key, aggregate them to the secret key share and make sure its public key matches the public key share calculated with the quorum verification vector for the masternode’s `protxHash`. | This can be wrapped into a workflow where a masternode which is a member of one or more quorums has lost its LLMQ DKG data. By requesting _0x0002_ it can recover its secret key share. When combined with _0x0001_, it can recover itself as a valid member of the LLMQ by just asking other LLMQ-Members for the required data after a re-sync/re-index. |
 
 # Reference implementation
 

--- a/dip-0023.md
+++ b/dip-0023.md
@@ -73,7 +73,7 @@ The payload of the Masternode Hard Fork Signalling Transaction (the new special 
 | Field | Type | Size | Description |
 |-|-|-|-|
 | version | uint_8 | 1 | Commitment special transaction version number. Currently set to 1. Please note that this is not the same as the version field of the `mnhfsignal` message |
-| commitment | mnhfsignal | 129 | This equals the payload of the `mnhfsignal` P2P message
+| commitment | mnhfsignal | 129 | This equals the payload of the `mnhfsignal` P2P message |
 
 **Stage 2:** Once this `mnhfsignal` message has been mined, two parameters are set:
 `masternode_activation_height` and `min_activation_height`. The cycle beginning at

--- a/dip-0024.md
+++ b/dip-0024.md
@@ -320,7 +320,7 @@ To select quorum quarters participants for a cycle, complete the following steps
     networks, only 1 confirmation is required. The `confirmedHash` block must have one confirmation
     itself before `confirmedHash` can be used.
 
-3. Determine the members of the previous 3 quarters for every quorum index. 
+3. Determine the members of the previous 3 quarters for every quorum index.
 4. Split the masternode list into 2 sections:
     1. Masternodes that are not in any quarter for any index found in step 3. These are masternodes
        that are unused at the start of this cycle.
@@ -535,32 +535,32 @@ The internal Dash message name is `getqrinfo` and the format of the message is:
 
 | Field | Type | Size | Description |
 |-|-|-|-|
-| num(baseBlockHashes) | compactSize uint | 1-9 | Number of masternode lists the light client knows
-| baseBlockHashes | uint256_t[] | 32 * baseBlockHashesNb | The base block hashes of the masternode lists the light client knows
-| blockRequestHash | uint256_t | 32 | Hash of the height the client is requesting
-| extraShare | bool | 1 | Flag to indicate if an extra share is requested. This extra share would support validation against the previous set of LLMQs.
+| num(baseBlockHashes) | compactSize uint | 1-9 | Number of masternode lists the light client knows |
+| baseBlockHashes | uint256_t[] | 32 * baseBlockHashesNb | The base block hashes of the masternode lists the light client knows |
+| blockRequestHash | uint256_t | 32 | Hash of the height the client is requesting |
+| extraShare | bool | 1 | Flag to indicate if an extra share is requested. This extra share would support validation against the previous set of LLMQs. |
 
 The internal Dash message name is `qrinfo` and the format of the message is:
 
 | Field | Type | Size | Description |
 |-|-|-|-|
-| quorumSnapshotAtHMinusC | CQuorumSnapshot | Variable | See below for sub-message contents
-| quorumSnapshotAtHMinus2C | CQuorumSnapshot | Variable | See below for sub-message contents
-| quorumSnapshotAtHMinus3C | CQuorumSnapshot | Variable | See below for sub-message contents
-| mnListDiffTip | CSimplifiedMNListDiff | Variable | See [DIP-4](https://github.com/dashpay/dips/blob/master/dip-0004.md) for details
-| mnListDiffH | CSimplifiedMNListDiff | Variable | As in [DIP-4](https://github.com/dashpay/dips/blob/master/dip-0004.md)
-| mnListDiffAtHMinusC | CSimplifiedMNListDiff | Variable | As in [DIP-4](https://github.com/dashpay/dips/blob/master/dip-0004.md)
-| mnListDiffAtHMinus2C | CSimplifiedMNListDiff | Variable | As in [DIP-4](https://github.com/dashpay/dips/blob/master/dip-0004.md)
-| mnListDiffAtHMinus3C | CSimplifiedMNListDiff | Variable | As in [DIP-4](https://github.com/dashpay/dips/blob/master/dip-0004.md)
-| extraShare | bool | 1 | Flag to indicate if an extra share is returned
-| quorumSnapshotAtHMinus4C | CQuorumSnapshot | Variable | Returned only if extraShare is on. See below for sub-message contents.
-| mnListDiffAtHMinus4C | CSimplifiedMNListDiff | Variable | Returned only if extraShare is on. As in [DIP-4](https://github.com/dashpay/dips/blob/master/dip-0004.md).
-| num(lastCommitmentPerIndex) | compactSize uint | 1-9 | Number of elements in lastCommitmentPerIndex
-| lastCommitmentPerIndex | qfcommit[] | Variable  | Contains the most recent commitment for each quorumIndex. Ordered by quorumIndex. See DIP-6 for [`qfcommit` details](https://github.com/dashpay/dips/blob/master/dip-0006.md#6-finalization-phase).
-| num(quorumSnapshotList) | compactSize uint | 1-9 | Number of elements in quorumSnapshotList
-| quorumSnapshotList | CQuorumSnapshot[] | Variable | The snapshots required to reconstruct the quorums built at h’ in lastCommitmentPerIndex. Ordered from oldest to newest.<p>**Note:** Only present if the most recent quorum for a quorumIndex is too old to be constructed with the info in the preceding fields.
-| num(mnListDiffList) | compactSize uint | 1-9 | Number of elements in mnListDiffList
-| mnListDiffList | CSimplifiedMNListDiff[] | Variable | The MNLISTDIFFs required to calculate older quorums. Ordered from oldest to newest.<p>**Note:** Only present if the most recent quorum for a quorumIndex is too old to be constructed with the info in the preceding fields.
+| quorumSnapshotAtHMinusC | CQuorumSnapshot | Variable | See below for sub-message contents |
+| quorumSnapshotAtHMinus2C | CQuorumSnapshot | Variable | See below for sub-message contents |
+| quorumSnapshotAtHMinus3C | CQuorumSnapshot | Variable | See below for sub-message contents |
+| mnListDiffTip | CSimplifiedMNListDiff | Variable | See [DIP-4](https://github.com/dashpay/dips/blob/master/dip-0004.md) for details |
+| mnListDiffH | CSimplifiedMNListDiff | Variable | As in [DIP-4](https://github.com/dashpay/dips/blob/master/dip-0004.md) |
+| mnListDiffAtHMinusC | CSimplifiedMNListDiff | Variable | As in [DIP-4](https://github.com/dashpay/dips/blob/master/dip-0004.md) |
+| mnListDiffAtHMinus2C | CSimplifiedMNListDiff | Variable | As in [DIP-4](https://github.com/dashpay/dips/blob/master/dip-0004.md) |
+| mnListDiffAtHMinus3C | CSimplifiedMNListDiff | Variable | As in [DIP-4](https://github.com/dashpay/dips/blob/master/dip-0004.md) |
+| extraShare | bool | 1 | Flag to indicate if an extra share is returned |
+| quorumSnapshotAtHMinus4C | CQuorumSnapshot | Variable | Returned only if extraShare is on. See below for sub-message contents. |
+| mnListDiffAtHMinus4C | CSimplifiedMNListDiff | Variable | Returned only if extraShare is on. As in [DIP-4](https://github.com/dashpay/dips/blob/master/dip-0004.md). |
+| num(lastCommitmentPerIndex) | compactSize uint | 1-9 | Number of elements in lastCommitmentPerIndex |
+| lastCommitmentPerIndex | qfcommit[] | Variable  | Contains the most recent commitment for each quorumIndex. Ordered by quorumIndex. See DIP-6 for [`qfcommit` details](https://github.com/dashpay/dips/blob/master/dip-0006.md#6-finalization-phase). |
+| num(quorumSnapshotList) | compactSize uint | 1-9 | Number of elements in quorumSnapshotList |
+| quorumSnapshotList | CQuorumSnapshot[] | Variable | The snapshots required to reconstruct the quorums built at h’ in lastCommitmentPerIndex. Ordered from oldest to newest.<p>**Note:** Only present if the most recent quorum for a quorumIndex is too old to be constructed with the info in the preceding fields. |
+| num(mnListDiffList) | compactSize uint | 1-9 | Number of elements in mnListDiffList |
+| mnListDiffList | CSimplifiedMNListDiff[] | Variable | The MNLISTDIFFs required to calculate older quorums. Ordered from oldest to newest.<p>**Note:** Only present if the most recent quorum for a quorumIndex is too old to be constructed with the info in the preceding fields. |
 
 Note: The different `MNLISTDIFF`s are the difference lists constructed from the difference of
 masternode lists at the respective heights and the closest masternode lists that the client claims
@@ -571,11 +571,11 @@ explained in [DIP-4](https://github.com/dashpay/dips/blob/master/dip-0004.md).
 
 | Field | Type | Size | Description |
 |-|-|-|-|
-| mnSkipListMode | int32_t | 4 | Mode of the skip list
-| num(activeQuorumMembers) | compactSize uint | 1-9 | Number of elements in activeQuorumMembers
-| activeQuorumMembers | cbitset | (num(activeQuorumMembers) + 7)/8 | The bitset of nodes already in quarters at the start of the cycle at height n
-| num(mnSkipList) | compactSize uint | 1-9 |Number of elements in mnSkipList
-| mnSkipList | int32_t[] | 4 * num(mnSkipList) | Skiplist at height n
+| mnSkipListMode | int32_t | 4 | Mode of the skip list |
+| num(activeQuorumMembers) | compactSize uint | 1-9 | Number of elements in activeQuorumMembers |
+| activeQuorumMembers | cbitset | (num(activeQuorumMembers) + 7)/8 | The bitset of nodes already in quarters at the start of the cycle at height n |
+| num(mnSkipList) | compactSize uint | 1-9 |Number of elements in mnSkipList |
+| mnSkipList | int32_t[] | 4 * num(mnSkipList) | Skiplist at height n |
 
 # Handling DKG Failure
 

--- a/dip-0025.md
+++ b/dip-0025.md
@@ -22,14 +22,14 @@ Currently headers are sent over the p2p network as a vector of `block_headers`, 
 
 |Field | Size |
 | - | - |
-|Version             | 4 bytes
-|Previous block hash | 32 bytes
-|Merkle root hash    | 32 bytes
-|Time                | 4 bytes
-|nBits               | 4 bytes
-|nonce               | 4 bytes
-|txn_count           | 1 byte
-|*Total*             | 81 bytes
+|Version             | 4 bytes |
+|Previous block hash | 32 bytes |
+|Merkle root hash    | 32 bytes |
+|Time                | 4 bytes |
+|nBits               | 4 bytes |
+|nonce               | 4 bytes |
+|txn_count           | 1 byte |
+|*Total*             | 81 bytes |
 
 Some fields can be removed completely, others can be compressed under certain conditions.
 
@@ -50,14 +50,14 @@ The following table illustrates the proposed `block_header2` data type specifica
 
 |Field               | Size     | Compressed |
 | -                  | -        | -          |
-|Bitfield            | 1 byte   | 1 byte
-|Version             | 4 bytes  | 0 \| 4 bytes
-|Previous block hash | 32 bytes | 0 \| 32 bytes
-|Merkle root hash    | 32 bytes | 32 bytes
-|Time                | 4 bytes  | 2 \| 4 bytes
-|nBits               | 4 bytes  | 0 \| 4 bytes
-|nonce               | 4 bytes  | 4 bytes
-|*Total*             | 81 bytes | range: 39 - 81 bytes
+|Bitfield            | 1 byte   | 1 byte |
+|Version             | 4 bytes  | 0 \| 4 bytes |
+|Previous block hash | 32 bytes | 0 \| 32 bytes |
+|Merkle root hash    | 32 bytes | 32 bytes |
+|Time                | 4 bytes  | 2 \| 4 bytes |
+|nBits               | 4 bytes  | 0 \| 4 bytes |
+|nonce               | 4 bytes  | 4 bytes |
+|*Total*             | 81 bytes | range: 39 - 81 bytes |
 
 This compression results in a maximum reduction from an 81 byte header to best-case 39 byte header. In bitcoin a continuous header sync from genesis (requiring a single full 81 byte header followed by only compressed `block_header2`) to height 629,474 was tested using this method and it resulted in a bandwidth reduction from 50.98MB down to 25.86MB, a saving of 49%.
 
@@ -67,11 +67,11 @@ To make parsing of header messages easier and further increase header compressio
 
 |Bit | Meaning + field size to read |
 | -  | -                            |
-|0<br>1<br>2    | Version: same as the last *distinct* value 1st ... 7th (0 byte field) or a new 32-bit distinct value (4 byte field).
-|3   | Previous block hash: Omitted (0 byte field) when bit is `0`; Included (32 byte field) when bit is `1`
-|4   | Timestamp: Small offset (2 byte field) when bit is `0`; Full timestamp (4 byte field) when bit is `1`
-|5   | nBits: Same as last header (0 byte field) when bit is `0`; New value (4 byte field) when bit is `1`
-|6+  | Undefined
+|0<br>1<br>2    | Version: same as the last *distinct* value 1st ... 7th (0 byte field) or a new 32-bit distinct value (4 byte field). |
+|3   | Previous block hash: Omitted (0 byte field) when bit is `0`; Included (32 byte field) when bit is `1` |
+|4   | Timestamp: Small offset (2 byte field) when bit is `0`; Full timestamp (4 byte field) when bit is `1` |
+|5   | nBits: Same as last header (0 byte field) when bit is `0`; New value (4 byte field) when bit is `1` |
+|6+  | Undefined |
 
 This bitfield adds 1 byte for every block in the chain.
 
@@ -91,7 +91,7 @@ The previous block hash will always be the X11 hash of `previous_header` so it i
 
 | Genesis to block | Current (B) | Compressed (B) | Saving (%) |
 | -                | -           | -              | -          |
-| 629,474          | 20,143,168  | 0              | 100
+| 629,474          | 20,143,168  | 0              | 100        |
 
 #### Time
 
@@ -99,7 +99,7 @@ The timestamp (in seconds) is consensus bound, based both on the time in the pre
 
 | Genesis to block | Current (B) | Compressed (B) | Saving (%) |
 | -                | -           | -              | -          |
-| 629,474          | 2,517,896   | 1,258,952      | 50
+| 629,474          | 2,517,896   | 1,258,952      | 50         |
 
 #### nBits
 
@@ -113,7 +113,7 @@ txn_count is included to make parsing of these messages compatible with parsing 
 
 | Genesis to block | Current (B) | Compressed (B) | Saving (%) |
 | -                | -           | -              | -          |
-| 629,474          | 629,474     | 0              | 100
+| 629,474          | 629,474     | 0              | 100        |
 
 ### Service Bit
 
@@ -127,12 +127,12 @@ Three new messages would be used by nodes that enable compact block header suppo
 
 The new p2p message required to request compact block headers would require the same fields as the current `getheaders` message:
 
-|Field Size | Description          | Data type | Comments
-| -         | -                    | -         | -
-|4          |version               |uint32_t   |The protocol version
-|1+         |hash count            |var_int    |Number of block locator hash entries
-|32+        |block locator hashes  |char[32]   |Block locator object; newest back to genesis block (dense to start, but then sparse)
-|32         |hash_stop             |char[32]   |Hash of the last desired block header; set to zero to get as many blocks as possible (2000)
+|Field Size | Description          | Data type | Comments |
+| -         | -                    | -         | - |
+|4          |version               |uint32_t   |The protocol version |
+|1+         |hash count            |var_int    |Number of block locator hash entries |
+|32+        |block locator hashes  |char[32]   |Block locator object; newest back to genesis block (dense to start, but then sparse) |
+|32         |hash_stop             |char[32]   |Hash of the last desired block header; set to zero to get as many blocks as possible (2000) |
 
 #### `sendheaders2` -- Request compact header announcements
 
@@ -146,10 +146,10 @@ For the motivational use-case it makes sense to also update this mechanism to su
 
 A `headers2` message is returned in response to `getheaders2` or at new header announcement following a `sendheaders2` request. It contains both `length` and `headers` fields. The `headers` field contains a variable length vector of `block_header2`:
 
-| Field Size | Description | Data type       | Comments
-| -          | -           | -               | -
-|1+          |length       |var_int          |Length of `headers`
-|39-81x?     |headers      |block_header2[]  |Compressed block headers in [block_header2 data type](#block_header2-data-type) format
+| Field Size | Description | Data type       | Comments |
+| -          | -           | -               | - |
+|1+          |length       |var_int          |Length of `headers` |
+|39-81x?     |headers      |block_header2[]  |Compressed block headers in [block_header2 data type](#block_header2-data-type) format |
 
 ### Implementation
 

--- a/dip-0026.md
+++ b/dip-0026.md
@@ -12,14 +12,14 @@
 
 ## Table of Contents
 
-- [Table of Contents](#table-of-contents)
-- [Abstract](#abstract)
-- [Motivation and Previous System](#motivation-and-previous-system)
-  - [Problems with the previous system](#problems-with-the-previous-system)
-- [Prior Work](#prior-work)
-- [Registering a Masternode (ProRegTx) and Updating Registrar of Masternode (ProUpRegTx)](#registering-a-masternode-proregtx-and-updating-registrar-of-masternode-proupregtx)
-  - [Validation Rules](#validation-rules)
-- [Copyright](#copyright)
+* [Table of Contents](#table-of-contents)
+* [Abstract](#abstract)
+* [Motivation and Previous System](#motivation-and-previous-system)
+  * [Problems with the previous system](#problems-with-the-previous-system)
+* [Prior Work](#prior-work)
+* [Registering a Masternode (ProRegTx) and Updating Registrar of Masternode (ProUpRegTx)](#registering-a-masternode-proregtx-and-updating-registrar-of-masternode-proupregtx)
+  * [Validation Rules](#validation-rules)
+* [Copyright](#copyright)
 
 ## Abstract
 
@@ -29,8 +29,8 @@ This DIP builds on the chain consensus for masternode lists laid forth in DIP000
 
 In the previous system, masternodes gained entry to the masternode list after the owner created a ProRegTx. This transaction provided key IDs for up to two roles that would receive masternode rewards payouts:
 
- * Owner
- * Operator
+* Owner
+* Operator
 
 ### Problems with the previous system
 
@@ -74,8 +74,6 @@ A ProRegTx or ProUpRegTx is invalid if any of these conditions are true (in addi
   1. Any `payoutShareReward` > 10000
   1. Sum of `payoutShareReward` for all `payoutShare` != 10000
 
-
 ## Copyright
 
 This document is licensed under the [MIT License.](https://opensource.org/licenses/MIT)
-

--- a/dip-0029.md
+++ b/dip-0029.md
@@ -221,14 +221,14 @@ following variables:
 
 | Variable | Description |
 | - | - |
-| `quorumHeight` | Height of the first block of the DKG
-| `cycleHeight` | Height of the first block of the first DKG of the cycle in the context of DIP-24
-| `quorumBaseBlockHash` | Hash of the block at height `quorumHeight`
-| `cycleBaseBlockHash` | Hash of the block at height `cycleHeight`
-| `quorumBaseBlockMinus8Hash` | Hash of the block at height `quorumHeight-8`
-| `cycleBaseBlockMinus8Hash` | Hash of the block at height `cycleHeight-8`
-| `quorumChainSig` | ChainLock contained in the block at height `quorumHeight-8`
-| `cycleChainSig` | ChainLock contained in the block at height `cycleHeight-8`
+| `quorumHeight` | Height of the first block of the DKG |
+| `cycleHeight` | Height of the first block of the first DKG of the cycle in the context of DIP-24 |
+| `quorumBaseBlockHash` | Hash of the block at height `quorumHeight` |
+| `cycleBaseBlockHash` | Hash of the block at height `cycleHeight` |
+| `quorumBaseBlockMinus8Hash` | Hash of the block at height `quorumHeight-8` |
+| `cycleBaseBlockMinus8Hash` | Hash of the block at height `cycleHeight-8` |
+| `quorumChainSig` | ChainLock contained in the block at height `quorumHeight-8` |
+| `cycleChainSig` | ChainLock contained in the block at height `cycleHeight-8` |
 
 In the initialization phase of every DKG, the masternode list is now respectively ordered by:
 
@@ -255,18 +255,18 @@ clients will require the ChainLocks used to shuffle the entries in the `newQuoru
 Consequently, the MNLISTDIFF will be enriched with the following fields, which will be inserted
 immediately after the existing `newQuorums` field:
 
-| Field | Type | Size | Description
+| Field | Type | Size | Description |
 | - | - | - | - |
-| quorumsCLSigsCount | compactSize uint | 1-9 | Number of `quorumsCLSigs` elements
-| quorumsCLSigs | quorumsCLSigsObject[] | variable | ChainLock signature used to calculate members per quorum indexes (in `newQuorums`)
+| quorumsCLSigsCount | compactSize uint | 1-9 | Number of `quorumsCLSigs` elements |
+| quorumsCLSigs | quorumsCLSigsObject[] | variable | ChainLock signature used to calculate members per quorum indexes (in `newQuorums`) |
 
 The content of `quorumsCLSigsObject`:
 
-| Field | Type | Size | Description
+| Field | Type | Size | Description |
 | - | - | - | - |
-| signature | BLSSig | 96 | ChainLock signature
-| indexSetCount | compactSize uint | 1-9 | Number of quorum indexes using the same `signature` for their member calculation
-| indexSet | uint16_t[] | variable | Quorum indexes indicating which `newQuorums` entries use this `signature` for their member calculation
+| signature | BLSSig | 96 | ChainLock signature |
+| indexSetCount | compactSize uint | 1-9 | Number of quorum indexes using the same `signature` for their member calculation |
+| indexSet | uint16_t[] | variable | Quorum indexes indicating which `newQuorums` entries use this `signature` for their member calculation |
 
 The same information is returned in the **protx diff** RPC. Example of the new field:
 


### PR DESCRIPTION
Fix most lint (as identified by [.markdownlint.json](https://github.com/dashpay/dips/blob/master/.markdownlint.json)) in DIPs that are not currently undergoing edits. Duplicate headings were not modified. Using "Display rich diff", you can see that no visible changes are introduced by the updates.