### PR TITLE
fix: the name of the hf to bump the withdrawals limit is `v23` now

### DIFF
--- a/dip-0027.md
+++ b/dip-0027.md
@@ -144,7 +144,7 @@ As a way to avoid a catastrophic failure if Platform is compromised, Core will l
 * It requests more DASH than the credit pool contains
 * The withdrawal would result in more than a 4000 DASH reduction in the credit pool over the past 576 blocks
 
-Prior to activation of the `withdrawals2` hard fork in Dash Core v23.0, more restrictive limits were followed. The withdrawal would not be mined if:
+Prior to activation of the `v23` hard fork in Dash Core v23.0, more restrictive limits were followed. The withdrawal would not be mined if:
 
 * The withdrawal would result in more than a 2000 DASH reduction in the credit pool over the past 576 blocks
 


### PR DESCRIPTION
See discussion in https://github.com/dashpay/dash/pull/6662

Follow-up for https://github.com/dashpay/dips/pull/165