### PR TITLE
docs: v2 asset locks - automatic funding + bech32 addresses

### DIFF
--- a/dip-0027.md
+++ b/dip-0027.md
@@ -20,6 +20,7 @@
 * [Overview](#overview)
 * [Asset Locking](#asset-locking)
   * [Asset Lock Transaction](#asset-lock-transaction)
+    * [Version 2: Automatic Credit Assignment](#version-2-automatic-credit-assignment)
   * [Proof of Finality](#proof-of-finality)
 * [Asset Unlocking](#asset-unlocking)
   * [Asset Unlock Transaction](#asset-unlock-transaction)
@@ -48,6 +49,7 @@ Switching to the credit pool relieves this issue by allowing withdrawals to be p
 * [DIP-0007: LLMQ Signing Requests / Sessions](https://github.com/dashpay/dips/blob/master/dip-0007.md)
 * [DIP-0010: LLMQ InstantSend](https://github.com/dashpay/dips/blob/master/dip-0010.md)
 * [DIP-0011: Identities](https://github.com/dashpay/dips/blob/master/dip-0011.md)
+* [DIP-0018: Dash Platform Payment Address Encodings](https://github.com/dashpay/dips/blob/master/dip-0018.md)
 
 ## System Requirements
 
@@ -83,6 +85,16 @@ Each Asset Lock transaction must create an unspendable output by using an OP_RET
 * It must not include any data
 * Its value is the amount of Dash to be locked
 * The sum of all TxOut amounts must equal the value of the output
+
+#### Version 2: Automatic Credit Assignment
+
+A `version = 2` Asset Lock transaction signals that each entry in `credit_outputs` MUST be automatically credited by Platform to the Identity matching the entry's public key hash or script hash, without an accompanying Identity Registration or Top-Up state transition.
+
+`version = 2` extends the set of allowed `credit_outputs[i].scriptPubKey` forms to `{P2PKH, P2SH}`; all other consensus rules are unchanged from `version = 1`.
+
+The `v24` hard fork enables `version = 2`: prior to activation only `version = 1` is valid; after activation `version ∈ {1, 2}` is valid.
+
+[DIP-0018](./dip-0018.md) Platform P2PKH addresses (`dash1k…`, `tdash1k…`) MUST be encoded as P2PKH `credit_outputs` entries; Platform P2SH addresses (`dash1s…`, `tdash1s…`) MUST be encoded as P2SH `credit_outputs` entries.
 
 ### Proof of Finality
 

--- a/dip-0027.md
+++ b/dip-0027.md
@@ -49,6 +49,7 @@ Switching to the credit pool relieves this issue by allowing withdrawals to be p
 * [DIP-0007: LLMQ Signing Requests / Sessions](https://github.com/dashpay/dips/blob/master/dip-0007.md)
 * [DIP-0010: LLMQ InstantSend](https://github.com/dashpay/dips/blob/master/dip-0010.md)
 * [DIP-0011: Identities](https://github.com/dashpay/dips/blob/master/dip-0011.md)
+* [DIP-0017: Dash Platform Payment Addresses and HD Derivation](https://github.com/dashpay/dips/blob/master/dip-0017.md)
 * [DIP-0018: Dash Platform Payment Address Encodings](https://github.com/dashpay/dips/blob/master/dip-0018.md)
 
 ## System Requirements
@@ -88,9 +89,9 @@ Each Asset Lock transaction must create an unspendable output by using an OP_RET
 
 #### Version 2: Automatic Credit Assignment
 
-A `version = 2` Asset Lock transaction signals that each entry in `credit_outputs` MUST be automatically credited by Platform to the Identity matching the entry's public key hash or script hash, without an accompanying Identity Registration or Top-Up state transition.
+When Dash Platform implemented the Platform address system defined by [DIP-17](https://github.com/dashpay/dips/blob/master/dip-0017.md), there was no way to directly fund a Platform address from the Core chain. Version 2 Asset Lock transactions enable transferring Core chain funds to Platform addresses by signalling that each entry in `credit_outputs` MUST be automatically credited to the Platform address matching the entry's public key hash or script hash. No accompanying state transition is required.
 
-`version = 2` extends the set of allowed `credit_outputs[i].scriptPubKey` forms to `{P2PKH, P2SH}`; all other consensus rules are unchanged from `version = 1`.
+Version 2 extends the set of allowed `credit_outputs[i].scriptPubKey` forms to `{P2PKH, P2SH}`; all other consensus rules are unchanged from version 1.
 
 The `v24` hard fork enables `version = 2`: prior to activation only `version = 1` is valid; after activation `version ∈ {1, 2}` is valid.
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Asset Lock Transaction Version 2 spec: Platform automatically credits outputs to Identities (no Registration/Top-Up required).
  * Expanded valid credit output script/address formats for version 2 and added an explicit address-encoding requirement referencing DIP-0018.
  * Documented v24 hard fork activation supporting both Asset Lock Transaction versions 1 and 2.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dashpay/dips/pull/182)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->